### PR TITLE
Fix admission generator in tests

### DIFF
--- a/committee_admissions/admissions/tests/test_api.py
+++ b/committee_admissions/admissions/tests/test_api.py
@@ -26,7 +26,9 @@ def fake_timedelta(days=0):
 def create_admission():
     base_date = timezone.now().replace(hour=23, minute=59, second=59, microsecond=59)
 
-    open_date = base_date.replace(hour=12, minute=15, second=0, microsecond=0)
+    open_date = base_date.replace(
+        hour=12, minute=15, second=0, microsecond=0
+    ) - timedelta(days=1)
     public_deadline_date = base_date + timedelta(days=7)
     application_deadline_date = base_date + timedelta(days=9)
 


### PR DESCRIPTION
Fix admission generator in tests so that tests can pass between 00:00 to 12:15 on any given day 😛