### PR TITLE
Fix navbar for portrait tablet size

### DIFF
--- a/frontend/src/components/NavBar/NavItem.js
+++ b/frontend/src/components/NavBar/NavItem.js
@@ -20,6 +20,7 @@ export default withRouter(NavItem);
 const Item = styled(NavLink)`
   font-weight: 600;
   color: var(--lego-font-color);
+  white-space: nowrap;
 
   &:nth-child(2n) {
     margin-right: 2rem;

--- a/frontend/src/components/NavBar/UserInfo.js
+++ b/frontend/src/components/NavBar/UserInfo.js
@@ -26,6 +26,11 @@ const Container = styled.div`
   margin: 10px;
   margin-right: 5rem;
 
+  ${media.portrait`        
+    margin-right: 1rem;
+    margin-left: 2rem;
+  `}
+
   ${media.handheld`        
     order: 2;
     display: inline;
@@ -43,13 +48,23 @@ const NameLogOutWrapper = styled.div`
     order: 2;
     display: inline-flex;
     flex-direction: row;
+    align-items: center;
   `}
 `;
 
 const Name = styled.span`
   font-weight: 600;
+  line-height: 0.8rem;
+
+  ${media.portrait`        
+    font-size: 0.8rem;
+    text-align: right;
+    margin-bottom: 5px;
+  `}
+
   ${media.handheld`        
     margin-right: 1rem;
+    margin-bottom: 0;
     font-size: 0.8rem;
   `}
 `;
@@ -72,6 +87,11 @@ const ProfilePicture = styled.img`
   height: 50px;
   border-radius: 50%;
   margin-left: 1rem;
+
+  ${media.portrait`        
+    width: 40px;
+    margin-left: 0.5rem;
+  `}
 
   ${media.handheld`        
     display: none;

--- a/frontend/src/components/NavBar/index.js
+++ b/frontend/src/components/NavBar/index.js
@@ -43,20 +43,26 @@ const Container = styled.nav`
 const BrandContainer = styled.div`
   width: 125px;
   margin: 0 2rem;
-
+  flex-shrink: 0;
   ${media.handheld`        
     margin: 1rem 0 5px 0;
     order: 1;
-  `}
+  `};
 `;
 
 const NavItemsContainer = styled.ul`
   display: flex;
   margin-left: 7rem;
+
+  ${media.portrait`  
+  margin-left: 0;
+
+        
+  `}
+
   ${media.handheld`        
     order: 3;
     margin-bottom: 1rem;
-    margin-left: 0;
     padding-top: 0.5rem;
     border-top: 1px solid var(--lego-gray-medium);
   `}


### PR DESCRIPTION
**Why was this prioritised?**
Because in split view on a 15" screen this is exactly when the problem occurs, and it is **sligthly** annoying. 😛 

Before:
<img width="649" alt="Screenshot 2019-08-22 at 14 01 58" src="https://user-images.githubusercontent.com/25204035/63513349-38719200-c4e6-11e9-9d43-364c3cbfaa9f.png">

After:
<img width="649" alt="Screenshot 2019-08-22 at 14 01 12" src="https://user-images.githubusercontent.com/25204035/63513353-3a3b5580-c4e6-11e9-9983-dde4f31e70b4.png">

Now it's only terrible for screens between 500px-640px 😄 
