### PR TITLE
Enable the ability to run LEGO&COMMITEE together

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,23 @@
 
 Recruitment for Abakom.
 
-## Setup project
+## Runnings LEGO and this repository in parallel
+
+> When working in development you want to have LEGO running (both frontend and backend). This allows you to create a oAuth application from the settings menu in the webapp.
+
+You need a total of **4 terminals**(or shells if you like).
+
+### Terminal 1
+
+Run LEGO by following the [README here](https://github.com/webkom/lego/blob/master/README.md)
+
+### Terminal 2
+
+Run LEGO-WEBAPP by following the [README here](https://github.com/webkom/lego-webapp/blob/master/README.md)
+
+### Terminal 3
+
+Run the committe_admissions backend by doing the following:
 
 Running the backend requires Python 3.6 and a `postgresql` database. The frontend requires `Node`. We recommend using
 a virtual environment. Create a `venv` in root using
@@ -15,7 +31,7 @@ $ source venv/bin/activate
 $ make dev_settings
 ```
 
-The `docker-compose.yml` file provides a `postgresql` database with correct config with the command
+The `docker-compose.yml` file provides a `postgresql` database. This uses a different port then LEGO, so you can run it in parallel.
 
 ```sh
 $ docker-compose up -d
@@ -34,37 +50,44 @@ $ pip install pip-tools
 $ pip-sync requirements/development.txt
 ```
 
-The `.env` file with secret keys is not included, but an `example.env` file has been provided in `./committe_admissions/settings`, so that you can simply rename the file and fill in the values. The secrets can be found at abakus.no after creating an application there. The project will not run without setting these variables.
+The `.env` file with secret keys is not included, but an `example.env` file has been provided in `./committe_admissions/settings`, so that you can simply rename the file and fill in the values. The secrets can be found at **localhost:3000** in the user settings menu after creating an application there. The project will not run without setting these variables.
 
 ```sh
-AUTH_LEGO_KEY="INSERT KEY"
-AUTH_LEGO_SECRET="INSERT SECRET"
-AUTH_LEGO_API_URL="https://lego-staging.abakus.no"
+# Create a copy of the example env file (run from the root of the project)
+$ cp /committee_admissions/settings/example.env /committee_admissions/settings/.env
+
+# Edit the file and change the KEY and SECRET
+AUTH_LEGO_KEY="Client ID from oAuth"
+AUTH_LEGO_SECRET="Client Secret from oAuth"
+AUTH_LEGO_API_URL="http://localhost:8000/"
 ```
 
-Now migrate the database and install frontend dependencies:
+Now you are ready to create some fixtures, migrate the database and run the server.
 
 ```sh
+# Create a custom admission for development
+$ python manage.py create_admission
+
+# Migrate the database migrations
 $ python manage.py migrate
-$ yarn
+
+# Run the Django server
+$ python manage.py runserver
 ```
 
-Now, you need two terminals to run this project, one for frontend and one for backend. Make sure the backend one has activated the virtualenv.
+> If coding over long periods of time, simply flush the db with `python manage.py flush` and run the server again.
 
-These are the start commands:
+### Terminal 4
+
+In the last terminal you are ready to start the frontend. Simply install the requirement and run the dev-server.
 
 ```sh
-$ python manage.py runserver
+# Install dependencies
+$ yarn
+
+# Start the dev-server
 $ yarn watch
 ```
-
-To populate the database with data for development, we use a custom command for creating an admission.
-
-```sh
-$ python manage.py create_admission
-```
-
-If coding over long periods of time, you want to update the dates that the admission is open (since it will eventually close). Either do it manually from shell, or simply flush the db (`python manage.py flush`) and run the above command again.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ Recruitment for Abakom.
 
 ## Runnings LEGO and this repository in parallel
 
-> When working in development you want to have LEGO running (both frontend and backend). This allows you to create a oAuth application from the settings menu in the webapp.
+> When working in development you want to have LEGO running (both frontend and backend). This allows you to create an OAuth2 application from the settings menu in the webapp.
 
 You need a total of **4 terminals**(or shells if you like).
 
 ### Terminal 1
 
-Run LEGO by following the [README here](https://github.com/webkom/lego/blob/master/README.md)
+Run LEGO by following the [README here](https://github.com/webkom/lego#readme)
 
 ### Terminal 2
 
-Run LEGO-WEBAPP by following the [README here](https://github.com/webkom/lego-webapp/blob/master/README.md)
+Run LEGO-WEBAPP by following the [README here](https://github.com/webkom/lego-webapp#readme)
 
 ### Terminal 3
 
@@ -31,7 +31,7 @@ $ source venv/bin/activate
 $ make dev_settings
 ```
 
-The `docker-compose.yml` file provides a `postgresql` database. This uses a different port then LEGO, so you can run it in parallel.
+The `docker-compose.yml` file provides a `postgresql` database. This uses a different port than LEGO, so you can run it in parallel.
 
 ```sh
 $ docker-compose up -d
@@ -50,26 +50,28 @@ $ pip install pip-tools
 $ pip-sync requirements/development.txt
 ```
 
-The `.env` file with secret keys is not included, but an `example.env` file has been provided in `./committe_admissions/settings`, so that you can simply rename the file and fill in the values. The secrets can be found at **localhost:3000** in the user settings menu after creating an application there. The project will not run without setting these variables.
+The `.env` file with secret keys is not included, but an `example.env` file has been provided in `./committe_admissions/settings`, so that you can simply rename the file and fill in the values.
+
+The secrets can be found at **localhost:3000** in the user settings menu after creating an OAuth2 app there. In the form enter `http://127.0.0.1:5000/complete/lego/` as the redirect url.
 
 ```sh
 # Create a copy of the example env file (run from the root of the project)
 $ cp /committee_admissions/settings/example.env /committee_admissions/settings/.env
 
 # Edit the file and change the KEY and SECRET
-AUTH_LEGO_KEY="Client ID from oAuth"
-AUTH_LEGO_SECRET="Client Secret from oAuth"
+AUTH_LEGO_KEY="Client ID from OAuth2"
+AUTH_LEGO_SECRET="Client Secret from OAuth2"
 AUTH_LEGO_API_URL="http://localhost:8000/"
 ```
 
-Now you are ready to create some fixtures, migrate the database and run the server.
+Now you are ready to migrate the database, create some fixtures, and run the server.
 
 ```sh
-# Create a custom admission for development
-$ python manage.py create_admission
-
 # Migrate the database migrations
 $ python manage.py migrate
+
+# Create a custom admission for development
+$ python manage.py create_admission
 
 # Run the Django server
 $ python manage.py runserver
@@ -88,6 +90,8 @@ $ yarn
 # Start the dev-server
 $ yarn watch
 ```
+
+> Now you are ready, go to 127.0.0.1:5000
 
 ## Requirements
 

--- a/committee_admissions/settings/development.py
+++ b/committee_admissions/settings/development.py
@@ -2,6 +2,10 @@ from .base import *
 
 # GENERAL CONFIGURATION =======================================================
 DEBUG = True
+if DEBUG:
+    # Override default port for `runserver` command
+    from django.core.management.commands.runserver import Command as runserver
+    runserver.default_port = "5000"
 SECRET_KEY = "secretkeythatisnotsosecret"
 
 # DATABASE CONFIGURATION ======================================================

--- a/committee_admissions/settings/development.py
+++ b/committee_admissions/settings/development.py
@@ -1,12 +1,11 @@
+from django.core.management.commands.runserver import Command as runserver
+
 from .base import *
 
 # GENERAL CONFIGURATION =======================================================
 DEBUG = True
-if DEBUG:
-    # Override default port for `runserver` command
-    from django.core.management.commands.runserver import Command as runserver
-    runserver.default_port = "5000"
 SECRET_KEY = "secretkeythatisnotsosecret"
+runserver.default_port = "5000"
 
 # DATABASE CONFIGURATION ======================================================
 DATABASES = {

--- a/committee_admissions/settings/development.py
+++ b/committee_admissions/settings/development.py
@@ -12,7 +12,7 @@ DATABASES = {
         "USER": "admissions",
         "PASSWORD": "",
         "HOST": "127.0.0.1",
-        "PORT": "5432",
+        "PORT": "5433",
     }
 }
 
@@ -59,7 +59,7 @@ SOCIAL_AUTH_LEGO_API_URL = env("AUTH_LEGO_API_URL", None)
 CORS_ALLOW_CREDENTIALS = True
 CORS_ORIGIN_WHITELIST = [
     "http://127.0.0.1:3000",
-    "http://localhost:3000",
-    "http://localhost:8000",
+    "http://127.0.0.1:5000",
+    "http://127.0.0.1:5001",
     "http://127.0.0.1:8000",
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,6 @@ services:
   postgres:
     image: postgres:9.5
     ports:
-      - '127.0.0.1:5432:5432'
+      - '127.0.0.1:5433:5432'
     environment:
       - POSTGRES_USER=admissions

--- a/frontend/src/utils/config.js
+++ b/frontend/src/utils/config.js
@@ -1,5 +1,5 @@
 const defaultConfig = {
-  API_URL: "http://localhost:8000/api"
+  API_URL: "http://127.0.0.1:5000/api"
 };
 const config = window.__CONFIG__
   ? { ...defaultConfig, ...window.__CONFIG__ }

--- a/server.js
+++ b/server.js
@@ -12,9 +12,9 @@ new WebpackDevServer(webpack(config), {
   inline: true,
   historyApiFallback: true,
   headers: { "Access-Control-Allow-Origin": "*" }
-}).listen(3000, "0.0.0.0", function(err) {
+}).listen(5001, "0.0.0.0", function(err) {
   if (err) {
     console.PluginError(err);
   }
-  console.log("Webpack HMR listening on port 0.0.0.0:3000");
+  console.log("Webpack HMR listening on port 5001");
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = {
         app: [
           "babel-polyfill",
           "whatwg-fetch",
-          "webpack-dev-server/client?http://localhost:3000",
+          "webpack-dev-server/client?http://127.0.0.1:5001",
           "webpack/hot/only-dev-server",
           "./frontend/src/index"
         ],
@@ -39,7 +39,7 @@ module.exports = {
     filename: "[name]-[hash].js",
     publicPath: isProduction
       ? "/static/bundles/"
-      : "http://localhost:3000/static/bundles/" // Use hot-reloading in DEV, otherwise hosted by django
+      : "http://127.0.0.1:5001/static/bundles/" // Use hot-reloading in DEV, otherwise hosted by django
   },
   devtool: isProduction ? "source-map" : "cheap-module-eval-source-map",
   optimization: {


### PR DESCRIPTION
This will allow the running of LEGO and COMMITTEE side by side on one's system. By switching over to some new ports

- `5000` for backend

- `5001` for website

- `5433` for PostgreSQL

**TODO**

- [x] Enable `5000` as default `runserver` port

- [x] Add docs for how to get both LEGO and this project up and running

- [x] Add docs for how to create oAuth application in LEGO for use in COMMITTEE

- [x] Fix/Check that drone runs right with the new conf