### PR TITLE
Add possibility to delete applications from admin page

### DIFF
--- a/committee_admissions/admissions/permissions.py
+++ b/committee_admissions/admissions/permissions.py
@@ -1,6 +1,6 @@
 from rest_framework import permissions
 
-from .models import LegoUser
+from .models import CommitteeApplication, LegoUser, UserApplication
 
 
 def can_edit_committee(user, committee):
@@ -57,4 +57,18 @@ class ApplicationPermissions(permissions.BasePermission):
         return False
 
     def has_permission(self, request, view):
+        return is_admin(request.user)
+
+
+class CommitteeApplicationPermissions(permissions.BasePermission):
+    def has_object_permission(self, request, view, obj):
+        if isinstance(obj, CommitteeApplication):
+            request.user.__class__ = LegoUser
+            return obj.committee == request.user.leader_of_committee
+        if isinstance(obj, UserApplication):
+            return CommitteeApplication.objects.filter(application=obj).count() == 0
+
+    def has_permission(self, request, view):
+        request.user.__class__ = LegoUser
+        # return request.user.is_privileged
         return is_admin(request.user)

--- a/committee_admissions/admissions/views.py
+++ b/committee_admissions/admissions/views.py
@@ -75,6 +75,8 @@ class ApplicationViewSet(viewsets.ModelViewSet):
         """
         if self.action in ["mine", "create"]:
             permission_classes = [permissions.IsAuthenticated]
+        elif self.action in ["delete_committee_application"]:
+            permission_classes = [permissions.IsAuthenticated, CommitteePermissions]
         else:
             permission_classes = [permissions.IsAuthenticated, ApplicationPermissions]
         return [permission() for permission in permission_classes]
@@ -120,6 +122,33 @@ class ApplicationViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
+
+    @action(detail=True, methods=["DELETE"])
+    def delete_committee_application(self, request, pk=None):
+        try:
+            self.request.user.__class__ = LegoUser
+            committee = None
+            if request.user.is_superuser:
+                committee_name = request.query_params.get("committee", None)
+                committee = Committee.objects.get(name=committee_name)
+            else:
+                committee = request.user.leader_of_committee
+            if committee is None:
+                return Response(status=status.HTTP_400_BAD_REQUEST)
+
+            CommitteeApplication.objects.get(
+                application=pk, committee=committee
+            ).delete()
+
+            if not CommitteeApplication.objects.filter(application=pk).exists():
+                # If this is the only application the user had left, we can
+                # delete the entire userApplication
+                UserApplication.objects.get(pk=pk).delete()
+            return Response(status=status.HTTP_200_OK)
+
+        except UserApplication.DoesNotExist:
+            # HTTP 204 No Content
+            return HttpResponse(status=204)
 
     @action(detail=False, methods=["GET", "DELETE"])
     def mine(self, request):

--- a/committee_admissions/admissions/views.py
+++ b/committee_admissions/admissions/views.py
@@ -27,6 +27,7 @@ from .authentication import SessionAuthentication
 from .permissions import (
     AdmissionPermissions,
     ApplicationPermissions,
+    CommitteeApplicationPermissions,
     CommitteePermissions,
 )
 
@@ -76,7 +77,7 @@ class ApplicationViewSet(viewsets.ModelViewSet):
         if self.action in ["mine", "create"]:
             permission_classes = [permissions.IsAuthenticated]
         elif self.action in ["delete_committee_application"]:
-            permission_classes = [permissions.IsAuthenticated, CommitteePermissions]
+            permission_classes = [CommitteeApplicationPermissions]
         else:
             permission_classes = [permissions.IsAuthenticated, ApplicationPermissions]
         return [permission() for permission in permission_classes]
@@ -123,7 +124,7 @@ class ApplicationViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
 
-    @action(detail=True, methods=["DELETE"])
+    @action(detail=True, methods=["DELETE"], url_name="delete_committee_application")
     def delete_committee_application(self, request, pk=None):
         try:
             self.request.user.__class__ = LegoUser

--- a/frontend/src/components/Application/DeleteApplication/index.js
+++ b/frontend/src/components/Application/DeleteApplication/index.js
@@ -1,0 +1,37 @@
+import React from "react";
+import LegoButton from "src/components/LegoButton";
+import ConfirmModal from "src/components/ConfirmModal";
+import callApi from "src/utils/callApi";
+
+const performDelete = (id, committee) => {
+  callApi(
+    `/application/${id}/delete_committee_application/${
+      committee ? `?committee=${committee}` : ""
+    }`,
+    {
+      method: "DELETE"
+    }
+  )
+    .then(() => location.reload())
+    .catch(err => {
+      alert("Det skjedde en feil.... ");
+      throw err;
+    });
+};
+
+const DeleteApplication = ({ id, committee }) => {
+  return (
+    <ConfirmModal
+      title="Slett søknad"
+      Component={({ onClick }) => (
+        <LegoButton icon="trash" onClick={onClick}>
+          Slett søknad
+        </LegoButton>
+      )}
+      message="Er du sikker på at du vil slette denne søknaden?"
+      onConfirm={() => performDelete(id, committee)}
+    />
+  );
+};
+
+export default DeleteApplication;

--- a/frontend/src/components/Application/index.js
+++ b/frontend/src/components/Application/index.js
@@ -4,8 +4,9 @@ import ReadMore from "src/components/ReadMore";
 
 import Wrapper from "./Wrapper";
 import CommitteeName from "./CommitteeName";
+import DeleteApplication from "./DeleteApplication";
 
-const Application = ({ text }) => {
+const Application = ({ text, applicationId }) => {
   const applicationText = text.split("\n").map((line, i, arr) => {
     const linee = <span key={i}>{line}</span>;
     if (i === arr.length - 1) {
@@ -20,6 +21,7 @@ const Application = ({ text }) => {
       <CommitteeName>Søknad</CommitteeName>
       <Wrapper>
         <ReadMore lines={200}>{applicationText}</ReadMore>
+        <DeleteApplication id={applicationId} />
       </Wrapper>
     </div>
   );

--- a/frontend/src/components/ApplicationAdminView/index.js
+++ b/frontend/src/components/ApplicationAdminView/index.js
@@ -8,7 +8,9 @@ import CommitteeLogo from "./CommitteeLogo";
 import SmallDescription from "./SmallDescription";
 import SmallDescriptionWrapper from "./SmallDescriptionWrapper";
 
-const ApplicationAdminView = ({ committee, text }) => {
+import DeleteApplication from "src/components/Application/DeleteApplication";
+
+const ApplicationAdminView = ({ committee, text, applicationId }) => {
   const applicationText = text.split("\n").map((line, i, arr) => {
     const linee = <span key={i}>{line}</span>;
     if (i === arr.length - 1) {
@@ -26,6 +28,7 @@ const ApplicationAdminView = ({ committee, text }) => {
       <SmallDescriptionWrapper>
         <SmallDescription>Søknad til ...</SmallDescription>
         <CommitteeName>{committee} </CommitteeName>
+        <DeleteApplication id={applicationId} committee={committee} />
       </SmallDescriptionWrapper>
 
       <ReadMore lines={3}>{applicationText}</ReadMore>

--- a/frontend/src/components/ConfirmModal/index.js
+++ b/frontend/src/components/ConfirmModal/index.js
@@ -23,8 +23,13 @@ class ConfirmModal extends Component {
       isOpen: true
     });
   };
+
+  confirmAction = () => {
+    this.props.onConfirm();
+    this.hideModal();
+  };
   render() {
-    const { onConfirm, title, message } = this.props;
+    const { title, message, Component } = this.props;
     const { isOpen } = this.state;
 
     return isOpen ? (
@@ -40,10 +45,12 @@ class ConfirmModal extends Component {
             >
               Cancel
             </ActionButton>
-            <ActionButton onClick={onConfirm}>Ja</ActionButton>
+            <ActionButton onClick={this.confirmAction}>Ja</ActionButton>
           </ButtonGroup>
         </ConfirmBox>
       </Overlay>
+    ) : Component ? (
+      <Component onClick={this.showModal} />
     ) : (
       <TriggerText onClick={this.showModal}>{title}</TriggerText>
     );

--- a/frontend/src/containers/UserApplication/index.js
+++ b/frontend/src/containers/UserApplication/index.js
@@ -30,7 +30,8 @@ class UserApplication extends Component {
       created_at,
       updated_at,
       applied_within_deadline,
-      phone_number
+      phone_number,
+      pk
     } = this.props;
 
     const CommitteeApplications = committee_applications.map(
@@ -50,8 +51,11 @@ class UserApplication extends Component {
             phone_number
           );
 
+          console.log(application);
+
           return (
             <Application
+              applicationId={pk}
               key={user.username + "-" + i}
               text={application.text}
             />

--- a/frontend/src/containers/UserApplication/index.js
+++ b/frontend/src/containers/UserApplication/index.js
@@ -51,8 +51,6 @@ class UserApplication extends Component {
             phone_number
           );
 
-          console.log(application);
-
           return (
             <Application
               applicationId={pk}

--- a/frontend/src/containers/UserApplicationAdminView/index.js
+++ b/frontend/src/containers/UserApplicationAdminView/index.js
@@ -31,7 +31,8 @@ class UserApplicationAdminView extends Component {
       created_at,
       updated_at,
       applied_within_deadline,
-      phone_number
+      phone_number,
+      pk
     } = this.props;
 
     committee_applications.sort(function(a, b) {
@@ -59,6 +60,7 @@ class UserApplicationAdminView extends Component {
           <ApplicationAdminView
             key={user.username + "-" + i}
             committee={application.committee.name}
+            applicationId={pk}
             text={application.text}
           />
         );

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ setenv =
     LANG=C.UTF-8
 passenv =
     DATABASE
-    DATABASE_PORT
 commands =
     coverage run --source=committee_admissions {toxinidir}/manage.py test committee_admissions
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ setenv =
     LANG=C.UTF-8
 passenv =
     DATABASE
+    DATABASE_PORT
 commands =
     coverage run --source=committee_admissions {toxinidir}/manage.py test committee_admissions
 


### PR DESCRIPTION
Adds an action endpoint to /applications/{pk} with the possibility to
delete a committee application.

Adds a button on both abakusLeader and commitee leader admin pages to
use this endpoint and delete applications.

The button is a bit ugly but I don't think that's too important really.

fixes #276 