### PR TITLE
Email should be EmailAddress as oAuth Serializer

### DIFF
--- a/committee_admissions/oauth.py
+++ b/committee_admissions/oauth.py
@@ -45,7 +45,7 @@ class LegoOAuth2(BaseOAuth2):
         )
         return {
             "username": response.get("username"),
-            "email": response.get("email") or "",
+            "email": response.get("emailAddress") or "",
             "fullname": fullname,
             "first_name": first_name,
             "last_name": last_name,


### PR DESCRIPTION
Fixes: https://github.com/webkom/committee-admissions/issues/283

With this change, the email gets fetched from LEGO OAuth
![image](https://user-images.githubusercontent.com/23152018/92020676-cff3fc80-ed58-11ea-8fc1-f89c9c37cdb8.png)
