### PR TITLE
Remove application_deadline form landingpage

### DIFF
--- a/frontend/src/routes/LandingPage/index.js
+++ b/frontend/src/routes/LandingPage/index.js
@@ -83,9 +83,8 @@ class LandingPage extends Component {
           <ApplicationDateInfo admission={admission} />
         </InfoBox>
         <Notice>
-          <StyledSpan bold>Merk:</StyledSpan> Oppdateringer etter
-          endringsfristen kan ikke garanteres å bli sett av komiteen(e) du søker
-          deg til.
+          <StyledSpan bold>Merk:</StyledSpan> Oppdateringer etter søknadsfristen
+          kan ikke garanteres å bli sett av komiteen(e) du søker deg til.
         </Notice>
         <LinkWrapper>
           {djangoData.user.full_name ? (
@@ -149,18 +148,6 @@ const ApplicationDateInfo = ({ admission }) => (
         <Moment format=", \k\l. HH:mm:ss">{admission.public_deadline}</Moment>
       </StyledSpan>
       .
-    </p>
-    <p>
-      Etter å ha lagt inn en søknad kan du{" "}
-      <StyledSpan bold>endre den</StyledSpan> frem til{" "}
-      <StyledSpan bold red>
-        <Moment format="dddd Do MMMM">{admission.application_deadline}</Moment>
-      </StyledSpan>
-      <StyledSpan red>
-        <Moment format=", \k\l. HH:mm:ss">
-          {admission.application_deadline}
-        </Moment>
-      </StyledSpan>
     </p>
   </div>
 );


### PR DESCRIPTION
It really looks like it's okay for the user to change their applications, and you need to read the "merk".

I think we can just remove the change date from this from the Landingpage, and just tell then that a "change" may not be seen. Then we just set the change date to a couple of days after the public deadline.

From
![image](https://user-images.githubusercontent.com/23152018/130863519-29846e1b-a295-40fb-98dd-d51852034100.png)

To 
![image](https://user-images.githubusercontent.com/23152018/130863866-269c8d3a-f79c-422b-9a8d-317babe7c738.png)


We will still keep this longer explanation longer down on the next page
![image](https://user-images.githubusercontent.com/23152018/130863940-69556134-b370-4fc6-967f-39dabc661486.png)

