### PR TITLE
improve the gui for the application recieved page

### DIFF
--- a/frontend/src/routes/ApplicationForm/FormStructure.js
+++ b/frontend/src/routes/ApplicationForm/FormStructure.js
@@ -185,24 +185,10 @@ const FormStructure = ({
                   </StyledSpan>
                   .
                 </ApplicationDateInfo>
-                <ApplicationDateInfo>
-                  Etter dette kan du <StyledSpan bold>endre den</StyledSpan>{" "}
-                  frem til{" "}
-                  <StyledSpan bold red>
-                    <Moment format="dddd Do MMMM">
-                      {admission.application_deadline}
-                    </Moment>
-                  </StyledSpan>
-                  <StyledSpan red>
-                    <Moment format=", \k\l. HH:mm:ss">
-                      {admission.application_deadline}
-                    </Moment>
-                  </StyledSpan>
-                </ApplicationDateInfo>
               </div>
             )}
             <SubmitInfo>
-              Oppdateringer etter endringsfristen kan ikke garanteres å bli sett
+              Oppdateringer etter søknadsfristen kan ikke garanteres å bli sett
               av komiteen(e) du søker deg til.
             </SubmitInfo>
             <SubmitInfo>


### PR DESCRIPTION
Changed a couple of things on "application recieved" page.
- The "Vi har mottatt søknaden din!" banner/card/whatever looked a lot like a button
- The deadline displayed was the application_deadline instead of the the public_deadline (see note at the end for explanation)
- Changed the explanatory text a bit so it (hopefully) is a bit clearer what the deadline actually means

Before:
![image](https://user-images.githubusercontent.com/69513864/130996106-da584bb2-6b5f-4b1d-b9c7-bdc66521e917.png)

Now:
![image](https://user-images.githubusercontent.com/69513864/130996126-0311c331-3530-431c-8074-b9eacdb1a2be.png)


Also removed the application_deadline from the text that's shown right nest to the "send inn søknad" button, so only the public_deadline is shown

Before:
![image](https://user-images.githubusercontent.com/69513864/131000480-fe6947a1-6f23-489b-b318-480b7b4ddd91.png)

Now:
![image](https://user-images.githubusercontent.com/69513864/131000526-ed0e8387-c31e-41c2-99e0-d0bda69eef6c.png)


note: for those confused by the two deadlines:

public_deadline: the official deadline for handling in an application (this is the one that Abakus tells all the new students).

application_deadline: a deadline we use in our system as an absolute deadline for editing an application. We don't want anyone to edit their application after the public_deadline but it is possible to do, we just can't guarantee that the committees will see it.

Considering this there is no reason to confuse the applicants by showing the application_deadline. I think the chances of someone misunderstanding is way lower by just showing the public_deadline and saying that we can't guarantee that the committees will see changes made after the public_deadline.