### PR TITLE
Rename to representative to remove confusion

### DIFF
--- a/committee_admissions/admissions/models.py
+++ b/committee_admissions/admissions/models.py
@@ -14,7 +14,7 @@ class LegoUser(AbstractUser):
     @property
     def is_privileged(self):
         """
-        Return true if the user has admission privileges
+        Return true if the user is Abakus Leader or has admission privileges
         """
         return bool(self.is_superuser or self.admission_privileges)
 
@@ -30,9 +30,9 @@ class LegoUser(AbstractUser):
         )
 
     @property
-    def leader_of_committee(self):
+    def representative_of_committee(self):
         """
-        Return the name of the committee this user is the leader for
+        Return the name of the committee this user is the representative for
         """
         membership = (
             Membership.objects.filter(user=self)

--- a/committee_admissions/admissions/permissions.py
+++ b/committee_admissions/admissions/permissions.py
@@ -23,7 +23,7 @@ class CommitteePermissions(permissions.BasePermission):
         user.__class__ = LegoUser
 
         # Here obj will be the name of the committee
-        if obj == user.leader_of_committee or user.is_superuser:
+        if obj == user.representative_of_committee or user.is_superuser:
             return True
 
         return False
@@ -59,7 +59,7 @@ class CommitteeApplicationPermissions(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         if isinstance(obj, CommitteeApplication):
             request.user.__class__ = LegoUser
-            return obj.committee == request.user.leader_of_committee
+            return obj.committee == request.user.representative_of_committee
         if isinstance(obj, UserApplication):
             return CommitteeApplication.objects.filter(application=obj).count() == 0
 

--- a/committee_admissions/admissions/tests/test_api.py
+++ b/committee_admissions/admissions/tests/test_api.py
@@ -1,7 +1,5 @@
 from datetime import timedelta
-from unittest import skip
 
-from django.contrib.auth.models import Group
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
@@ -470,7 +468,7 @@ class DeleteComitteeApplicationsTestCase(APITestCase):
     Tests for api endpoint allowing leader of committee / opptaksansvarlig and abakus_leader to delete committee
     applications
 
-    leader_of_committee can only delete applications to their own committee. abakus_leader can
+    representative_of_committee can only delete applications to their own committee. abakus_leader can
     delete any committee applications.
 
     Users can delete their own applications with the /mine endpoint

--- a/committee_admissions/admissions/views.py
+++ b/committee_admissions/admissions/views.py
@@ -7,7 +7,6 @@ from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from committee_admissions.admissions import constants
 from committee_admissions.admissions.models import (
     Admission,
     Committee,
@@ -98,7 +97,7 @@ class ApplicationViewSet(viewsets.ModelViewSet):
                 )
             )
 
-        committee = user.leader_of_committee
+        committee = user.representative_of_committee
         qs = CommitteeApplication.objects.filter(committee=committee).select_related(
             "committee"
         )
@@ -133,7 +132,7 @@ class ApplicationViewSet(viewsets.ModelViewSet):
                 committee_name = request.query_params.get("committee", None)
                 committee = Committee.objects.get(name=committee_name)
             else:
-                committee = request.user.leader_of_committee
+                committee = request.user.representative_of_committee
             if committee is None:
                 return Response(status=status.HTTP_400_BAD_REQUEST)
 

--- a/committee_admissions/oauth.py
+++ b/committee_admissions/oauth.py
@@ -2,7 +2,6 @@ from django.db import transaction
 
 from six.moves.urllib.parse import urljoin
 from social_core.backends.oauth import BaseOAuth2
-from social_core.exceptions import AuthFailed
 
 from committee_admissions.admissions import constants
 from committee_admissions.admissions.models import Committee, Membership
@@ -108,7 +107,8 @@ def update_custom_user_details(strategy, details, user=None, *args, **kwargs):
         Membership.objects.filter(user=user).delete()
         user.is_superuser = False
         for group, membership in group_data:
-
+            # This check finds the leader of Abakus by looking at the group leader
+            # of Hovedstyret. This is the only superuser of this application.
             if (
                 group["name"] == "Hovedstyret"
                 and membership["role"] == constants.LEADER
@@ -123,7 +123,8 @@ def update_custom_user_details(strategy, details, user=None, *args, **kwargs):
                 continue
 
             committee = Committee.objects.get(pk=group["id"])
-
+            # For all other committee memebers their role is set
+            # This is used later on when we check if they are Leader or Recruitment
             Membership.objects.create(
                 user=user, committee=committee, role=membership["role"]
             )

--- a/committee_admissions/templates/index.html
+++ b/committee_admissions/templates/index.html
@@ -35,7 +35,7 @@
         is_superuser: {{ request.user.is_superuser|yesno:"true,false" }},
         is_privileged: {{ request.user.is_privileged|yesno:"true,false" }},
         has_application: {{ request.user.has_application|yesno:"true,false" }},
-        leader_of_committee: "{{ request.user.leader_of_committee }}"
+        representative_of_committee: "{{ request.user.representative_of_committee }}"
 
       }
     };

--- a/committee_admissions/utils/management/commands/create_admission.py
+++ b/committee_admissions/utils/management/commands/create_admission.py
@@ -1,5 +1,3 @@
-import os
-import subprocess
 from datetime import timedelta
 
 from django.core.management.base import BaseCommand

--- a/frontend/src/containers/UserApplication/index.js
+++ b/frontend/src/containers/UserApplication/index.js
@@ -38,7 +38,7 @@ class UserApplication extends Component {
       (application, i) => {
         if (
           application.committee.name.toLowerCase() ==
-          djangoData.user.leader_of_committee.toLowerCase()
+          djangoData.user.representative_of_committee.toLowerCase()
         ) {
           this.props.generateCSVData(
             user.full_name,

--- a/frontend/src/routes/AdminPage/index.js
+++ b/frontend/src/routes/AdminPage/index.js
@@ -131,7 +131,7 @@ class AdminPage extends Component {
       var filteredComApp = userApplication.committee_applications.filter(
         committeeApplication =>
           committeeApplication.committee.name.toLowerCase() ==
-          djangoData.user.leader_of_committee.toLowerCase()
+          djangoData.user.representative_of_committee.toLowerCase()
       );
 
       return filteredComApp.length > 0;
@@ -143,7 +143,7 @@ class AdminPage extends Component {
         <UserApplication
           key={i}
           {...userApplication}
-          whichCommitteeLeader={djangoData.user.leader_of_committee}
+          whichCommitteeLeader={djangoData.user.representative_of_committe}
           generateCSVData={this.generateCSVData}
         />
       );
@@ -151,7 +151,7 @@ class AdminPage extends Component {
     const committee = this.props.committees.find(
       committee =>
         committee.name.toLowerCase() ===
-        djangoData.user.leader_of_committee.toLowerCase()
+        djangoData.user.representative_of_committee.toLowerCase()
     );
 
     const committeeId = committee && committee.pk;
@@ -170,18 +170,18 @@ class AdminPage extends Component {
             <CommitteeLogo
               src={
                 committee_logos[
-                  djangoData.user.leader_of_committee.toLowerCase()
+                  djangoData.user.representative_of_committee.toLowerCase()
                 ]
               }
             />
-            <h2>{djangoData.user.leader_of_committee}</h2>
+            <h2>{djangoData.user.representative_of_committee}</h2>
           </CommitteeLogoWrapper>
           <LinkLink to="/">Gå til forside</LinkLink>
 
           <Wrapper>
             <EditCommitteeForm
               apiRoot={this.API_ROOT}
-              committee={djangoData.user.leader_of_committee}
+              committee={djangoData.user.representative_of_committee}
               initialDescription={committee && committee.description}
               initialReplyText={committee && committee.response_label}
               committeeId={committeeId}


### PR DESCRIPTION
We made some changes last year with the REC role, where they could also do everything that the LEADER could do. We made a quicky then, and left the codebase a little messy with LEADER and REC being the `leader_of_committee`.

This aims to clean up this, and call them the "representative_of_committee", and give them the same permissions.