### PR TITLE
Add extra info to comment field

### DIFF
--- a/frontend/src/routes/ApplicationForm/FormStructure.js
+++ b/frontend/src/routes/ApplicationForm/FormStructure.js
@@ -117,6 +117,9 @@ const FormStructure = ({
           <Icon name="information-circle-outline" />
           Kun leder av Abakus kan se det du skriver inn i prioriterings- og
           kommentarfeltet.
+          <Icon name="information-circle-outline" />
+          Det er ikke sikkert prioriteringslisten vil bli tatt hensyn til. Ikke
+          søk på en komite du ikke ønsker å bli med i.
         </HelpText>
         <Field
           name="priorityText"


### PR DESCRIPTION
Add some extra information to the priorities field explaining that that the applicants priorities may not be taken into consideration. This was requested by the board as well as the different committee heads in order to avoid having applicants end up in a committee they did not want to be in.