### PR TITLE
Escape quotation mark in application when exporting to csv

### DIFF
--- a/frontend/src/routes/AdminPage/index.js
+++ b/frontend/src/routes/AdminPage/index.js
@@ -14,6 +14,8 @@ import LoadingBall from "src/components/LoadingBall";
 
 import CSRFToken from "./csrftoken";
 
+import { replaceQuotationMarks } from "../../utils/replaceQuotationMarks";
+
 import {
   EditCommitteeFormWrapper,
   FormWrapper,
@@ -90,7 +92,7 @@ class AdminPage extends Component {
           name,
           email,
           username,
-          applicationText: applicationText.replaceAll('"', "'"),
+          applicationText: replaceQuotationMarks(applicationText),
           createdAt,
           updatedAt,
           appliedWithinDeadline,

--- a/frontend/src/routes/AdminPage/index.js
+++ b/frontend/src/routes/AdminPage/index.js
@@ -90,7 +90,7 @@ class AdminPage extends Component {
           name,
           email,
           username,
-          applicationText,
+          applicationText: applicationText.replaceAll('"', "'"),
           createdAt,
           updatedAt,
           appliedWithinDeadline,

--- a/frontend/src/routes/AdminPageAbakusLeaderView/index.js
+++ b/frontend/src/routes/AdminPageAbakusLeaderView/index.js
@@ -69,9 +69,14 @@ class AdminPage extends Component {
           updatedAt,
           appliedWithinDeadline,
           priorityText:
-            priorityText != "" ? priorityText : "Ingen prioriteringer",
+            priorityText != ""
+              ? priorityText.replaceAll('"', "'")
+              : "Ingen prioriteringer",
           committee,
-          committeeApplicationText,
+          committeeApplicationText: committeeApplicationText.replaceAll(
+            '"',
+            "'"
+          ),
           phoneNumber
         }
       ]

--- a/frontend/src/routes/AdminPageAbakusLeaderView/index.js
+++ b/frontend/src/routes/AdminPageAbakusLeaderView/index.js
@@ -18,6 +18,7 @@ import Statistics from "./Statistics";
 import CommitteeStatistics from "./CommitteeStatistics";
 import StatisticsName from "./StatisticsName";
 import StatisticsWrapper from "./StatisticsWrapper";
+import { replaceQuotationMarks } from "../../utils/replaceQuotationMarks";
 
 class AdminPage extends Component {
   constructor(props) {
@@ -70,12 +71,11 @@ class AdminPage extends Component {
           appliedWithinDeadline,
           priorityText:
             priorityText != ""
-              ? priorityText.replaceAll('"', "'")
+              ? replaceQuotationMarks(priorityText)
               : "Ingen prioriteringer",
           committee,
-          committeeApplicationText: committeeApplicationText.replaceAll(
-            '"',
-            "'"
+          committeeApplicationText: replaceQuotationMarks(
+            committeeApplicationText
           ),
           phoneNumber
         }

--- a/frontend/src/utils/replaceQuotationMarks.js
+++ b/frontend/src/utils/replaceQuotationMarks.js
@@ -1,0 +1,1 @@
+export const replaceQuotationMarks = text => text.replaceAll('"', "'");


### PR DESCRIPTION
Solves #397 

I've changed so that all " in user input texts are replaced with ' when exporting to csv. This solves the problem we had when exporting the csv, since the ' in the application text won't be confused with the " used as the enclosing character for the csv fields (which was the problem before).

PS: Comma is still the separator used in the csv file, but I did not bother to replace all commas with anything, as the problem arises when you have a combination of " and , and it is read as the and of one field and then a seperator and then the start of another. Having just commas in the application texts should not be a problem as long as they're not paired with " (and vise versa, but i figured it would be less of a problem to replace " with ' than to find something to replace all commas with) 