### PR TITLE
Commit production dependency upgrades that were not added in #509

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,23 +6,25 @@
 #
 asttokens==2.0.5
     # via stack-data
-backcall==0.1.0
+backcall==0.2.0
     # via ipython
-certifi==2018.8.13
+build==0.8.0
+    # via pip-tools
+certifi==2022.6.15
     # via
     #   requests
     #   sentry-sdk
-cffi==1.15.0
+cffi==1.15.1
     # via cryptography
-chardet==3.0.4
+charset-normalizer==2.1.0
     # via requests
-click==6.7
+click==8.1.3
     # via pip-tools
-cryptography==36.0.2
+cryptography==37.0.4
     # via social-auth-core
-decorator==4.3.0
+decorator==5.1.1
     # via ipython
-defusedxml==0.5.0
+defusedxml==0.7.1
     # via
     #   python3-openid
     #   social-auth-core
@@ -44,81 +46,91 @@ djangorestframework==3.13.1
     # via -r requirements/base.in
 executing==0.8.3
     # via stack-data
-idna==2.7
+idna==3.3
     # via requests
 ipython==8.4.0
     # via -r requirements/base.in
-jedi==0.17.2
+jedi==0.18.1
     # via ipython
 matplotlib-inline==0.1.3
     # via ipython
-oauthlib==3.1.0
+oauthlib==3.2.0
     # via
     #   requests-oauthlib
     #   social-auth-core
-parso==0.7.1
+packaging==21.3
+    # via build
+parso==0.8.3
     # via jedi
-pexpect==4.6.0
+pep517==0.12.0
+    # via build
+pexpect==4.8.0
     # via ipython
-pickleshare==0.7.4
+pickleshare==0.7.5
     # via ipython
-pip-tools==4.0.0
+pip-tools==6.8.0
     # via -r requirements/base.in
-prompt-toolkit==2.0.9
+prompt-toolkit==3.0.30
     # via ipython
 psycopg2-binary==2.8.6
     # via -r requirements/base.in
-ptyprocess==0.6.0
+ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
 pycparser==2.21
     # via cffi
-pygments==2.7.4
+pygments==2.12.0
     # via ipython
-pyjwt==2.3.0
+pyjwt==2.4.0
     # via social-auth-core
-python3-openid==3.1.0
+pyparsing==3.0.9
+    # via packaging
+python3-openid==3.2.0
     # via social-auth-core
-pytz==2018.5
+pytz==2022.1
     # via
     #   django
     #   djangorestframework
-requests==2.22.0
+requests==2.28.1
     # via
     #   requests-oauthlib
     #   social-auth-core
-requests-oauthlib==1.2.0
+requests-oauthlib==1.3.1
     # via social-auth-core
 sentry-sdk==1.7.2
     # via -r requirements/base.in
-six==1.11.0
-    # via
-    #   asttokens
-    #   pip-tools
-    #   prompt-toolkit
+six==1.16.0
+    # via asttokens
 social-auth-app-django==5.0.0
     # via -r requirements/base.in
-social-auth-core==4.2.0
+social-auth-core==4.3.0
     # via social-auth-app-django
-sqlparse==0.3.0
+sqlparse==0.4.2
     # via django
 stack-data==0.3.0
     # via ipython
 structlog==21.5.0
     # via -r requirements/base.in
+tomli==2.0.1
+    # via
+    #   build
+    #   pep517
 traitlets==5.3.0
     # via
     #   ipython
     #   matplotlib-inline
-urllib3==1.25.8
+urllib3==1.26.10
     # via
     #   requests
     #   sentry-sdk
 uwsgi==2.0.20
     # via -r requirements/production.in
-wcwidth==0.1.7
+wcwidth==0.2.5
     # via prompt-toolkit
+wheel==0.37.1
+    # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools


### PR DESCRIPTION
Discovered that I ran `pip-compile requirements/production.in` without the `--upgrade` flag in pr #509.