### PR TITLE
Redesign header section of submitted application to match Figma

### DIFF
--- a/frontend/src/routes/ApplicationForm/FormStructure.js
+++ b/frontend/src/routes/ApplicationForm/FormStructure.js
@@ -36,52 +36,64 @@ const FormStructure = ({
       <RecieptInfo>
         <Title>Kvittering for sendt søknad</Title>
         <RecievedApplicationBanner>
-          <Icon name="checkmark-circle-outline" size="5rem" />
-          <br />
-          Vi har mottatt søknaden din!
-          <TimeStamp>
-            <Icon name="time" />
-            Sist oppdatert
-            {myApplication && (
-              <StyledSpan bold>
-                <Moment format="dddd Do MMMM , \k\l. HH:mm:ss">
-                  {myApplication.updated_at}
-                </Moment>
-              </StyledSpan>
-            )}
-          </TimeStamp>
+          <span>Vi har mottatt søknaden din!</span>
+          <Icon name="checkmark" size="1.8rem" />
         </RecievedApplicationBanner>
-        <Text>
-          Du kan
-          <StyledSpan bold> fritt endre søknaden</StyledSpan> din frem til{" "}
-          {admission && (
-            <StyledSpan bold red>
-              <Moment format="dddd Do MMMM">{admission.public_deadline}</Moment>
+        <TimeStamp>
+          <Icon name="time" />
+          Søknaden ble sist registrert
+          {myApplication && (
+            <StyledSpan bold>
+              <Moment format="dddd Do MMMM, \k\l. HH:mm:ss">
+                {myApplication.updated_at}
+              </Moment>
             </StyledSpan>
-          )}{" "}
-          og komiteene vil kun se den siste versjonen.
-        </Text>
-        <LegoButton
-          icon="arrow-forward"
-          iconPrefix="ios"
-          onClick={toggleIsEditing}
-        >
-          Endre søknad
-        </LegoButton>
-        <Notice>
-          <StyledSpan bold>Merk:</StyledSpan> Oppdateringer etter søknadsfristen
-          kan ikke garanteres å bli sett av komiteen(e) du søker deg til.
-        </Notice>
-        <ConfirmModal
-          title="Slett søknad"
-          Component={({ onClick }) => (
-            <LegoButton icon="trash" onClick={onClick}>
-              Slett søknad
-            </LegoButton>
           )}
-          message="Er du sikker på at du vil slette søknaden din?"
-          onConfirm={() => onDeleteApplication()}
-        />
+        </TimeStamp>
+        <EditWrapper>
+          <EditInfo>
+            <Text>
+              Du kan
+              <StyledSpan bold> fritt endre søknaden</StyledSpan> din frem til{" "}
+              {admission && (
+                <StyledSpan bold red>
+                  <Moment format="dddd Do MMMM">
+                    {admission.public_deadline}
+                  </Moment>
+                </StyledSpan>
+              )}{" "}
+              og komiteene vil kun se den siste versjonen.
+            </Text>
+            <Notice>
+              <StyledSpan bold>Merk:</StyledSpan> Oppdateringer etter
+              søknadsfristen kan ikke garanteres å bli sett av komiteen(e) du
+              søker deg til.
+            </Notice>
+          </EditInfo>
+          <EditActions>
+            <LegoButton
+              icon="arrow-forward"
+              iconPrefix="ios"
+              onClick={toggleIsEditing}
+            >
+              Endre søknad
+            </LegoButton>
+            <ConfirmModal
+              title="Slett søknad"
+              Component={({ onClick }) => (
+                <LegoButton
+                  onClick={onClick}
+                  buttonStyle="secondary"
+                  size="medium"
+                >
+                  Slett søknad
+                </LegoButton>
+              )}
+              message="Er du sikker på at du vil slette søknaden din?"
+              onConfirm={() => onDeleteApplication()}
+            />
+          </EditActions>
+        </EditWrapper>
       </RecieptInfo>
     )}
 
@@ -246,7 +258,8 @@ const PageWrapper = styled.div`
   }
 
   ${media.portrait`
-    max-width: 500px;
+    max-width: 80%;
+    width: 600px;
   `};
 
   ${media.handheld`
@@ -276,7 +289,7 @@ const SeparatorLine = styled.div`
 const FormHeader = styled.div`
   display: flex;
   justify-content: space-between;
-  width: 750px;
+  max-width: 750px;
   margin: 1em 0 1em 0;
 
   ${media.handheld`
@@ -528,33 +541,71 @@ const RecieptInfo = styled.div`
 `;
 
 const RecievedApplicationBanner = styled.div`
-  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-items: space-between;
   background: var(--lego-green);
   border: 1px solid #809e33;
   border-radius: 13px;
   padding: 0.8rem 2rem;
   color: var(--lego-white);
   font-weight: 600;
-  font-size: 1.2rem;
+  font-size: 1.1rem;
+
+  > span {
+    margin-right: 1rem;
+  }
 
   ${media.handheld`
   font-size: 1rem;
   `};
 `;
 
+const EditWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  max-width: 750px;
+`;
+
+const EditInfo = styled.div`
+  flex-basis: 60%;
+
+  ${media.portrait`
+  flex-basis: 100%;
+  `}
+`;
+
+const EditActions = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-basis: 40%;
+  justify-content: center;
+
+  > button {
+    margin: 0.4rem auto;
+  }
+
+  ${media.portrait`
+  flex-basis: 100%;
+  `}
+`;
+
 const TimeStamp = styled.p`
   text-align: center;
-  display: flex;
-  align-items: center;
   font-size: 1.1rem;
+  line-height: 1.8rem;
 
   span {
     margin-left: 0.3rem;
   }
 
   i {
-    margin-right: 1rem;
+    margin-right: 0.7rem;
     font-size: 1.4rem;
+    vertical-align: top;
+    line-height: inherit;
   }
 
   ${media.handheld`


### PR DESCRIPTION
Resolves #230 

Wanted to try it out to see how it looks, and personally I prefer the new look compared to the old one.  
I noticed that the button style was changed in https://github.com/webkom/committee-admissions/pull/406, but I argue that now that the button style is red and the secondary buttonStyle has an underline it is sufficiently clear that it is a button.

Also fixes some x-overflows (width -> max-width).

Old design:
![image](https://user-images.githubusercontent.com/13599770/184404973-df2fa0e7-4322-4b03-bf17-c5fa69438522.png)
![image](https://user-images.githubusercontent.com/13599770/184404909-d95087a0-08b8-4e01-a64f-f5ae563fcc32.png)

New design:
![image](https://user-images.githubusercontent.com/13599770/184404784-6c4225a9-1263-4d7b-992f-d5ba39745f40.png)
![image](https://user-images.githubusercontent.com/13599770/184404834-a87f207b-9add-4424-8f56-5b6bf73e813c.png)
