### PR TITLE
Implement react-query to handle API calls and cache

### DIFF
--- a/frontend/src/components/Application/DeleteApplication/index.js
+++ b/frontend/src/components/Application/DeleteApplication/index.js
@@ -18,10 +18,10 @@ const DeleteWrapper = styled.div`
     `};
 `;
 
-const performDelete = (id, group) => {
+const performDelete = (id, groupName) => {
   callApi(
     `/application/${id}/delete_group_application/${
-      group ? `?group=${group}` : ""
+      groupName ? `?group=${groupName}` : ""
     }`,
     {
       method: "DELETE",
@@ -34,7 +34,7 @@ const performDelete = (id, group) => {
     });
 };
 
-const DeleteApplication = ({ id, group }) => {
+const DeleteApplication = ({ id, groupName }) => {
   return (
     <DeleteWrapper>
       <ConfirmModal
@@ -45,7 +45,7 @@ const DeleteApplication = ({ id, group }) => {
           </LegoButton>
         )}
         message="Er du sikker på at du vil slette denne søknaden?"
-        onConfirm={() => performDelete(id, group)}
+        onConfirm={() => performDelete(id, groupName)}
       />
     </DeleteWrapper>
   );

--- a/frontend/src/components/ApplicationAdminView/index.js
+++ b/frontend/src/components/ApplicationAdminView/index.js
@@ -25,11 +25,10 @@ const ApplicationAdminView = ({ group, text, applicationId }) => {
       <GroupLogo src={group.logo} />
       <SmallDescriptionWrapper>
         <SmallDescription>Søknad til ...</SmallDescription>
-        <GroupName>{group} </GroupName>
-        <DeleteApplication id={applicationId} group={group} />
+        <GroupName>{group.name} </GroupName>
+        <ReadMore lines={3}>{applicationText}</ReadMore>
+        <DeleteApplication id={applicationId} groupName={group.name} />
       </SmallDescriptionWrapper>
-
-      <ReadMore lines={3}>{applicationText}</ReadMore>
     </Wrapper>
   );
 };

--- a/frontend/src/containers/UserApplicationAdminView/index.js
+++ b/frontend/src/containers/UserApplicationAdminView/index.js
@@ -14,6 +14,7 @@ import SmallDescription from "./SmallDescription";
 import SmallDescriptionWrapper from "./SmallDescriptionWrapper";
 import Header from "./Header";
 import NumApplications from "./NumApplications";
+import { useGroups } from "../../query/hooks";
 
 const UserApplicationAdminView = ({
   user,
@@ -25,6 +26,8 @@ const UserApplicationAdminView = ({
   phone_number,
   pk,
 }) => {
+  const { data: groups } = useGroups();
+
   const sortedGroupApplications = useMemo(() =>
     [...group_applications].sort((a, b) =>
       a.group.name.localeCompare(b.group.name)
@@ -86,7 +89,9 @@ const UserApplicationAdminView = ({
             {sortedGroupApplications.map((application) => (
               <ApplicationAdminView
                 key={user.username + "-" + application.group.name}
-                group={application.group.name}
+                group={groups.find(
+                  (group) => group.pk === application.group.pk
+                )}
                 applicationId={pk}
                 text={application.text}
               />

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { BrowserRouter as Router, useRoutes } from "react-router-dom";
 import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { defaultQueryFn } from "./query/queries";
 
 import NotFoundPage from "src/routes/NotFoundPage";
 import LandingPage from "src/routes/LandingPage/";
@@ -28,6 +30,17 @@ Sentry.init({
   },
 });
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: process.env.NODE_ENV === "production",
+      refetchOnWindowFocus: process.env.NODE_ENV === "production",
+      queryFn: defaultQueryFn,
+      staleTime: 60000,
+    },
+  },
+});
+
 const container = document.getElementById("root");
 const root = createRoot(container);
 
@@ -41,17 +54,17 @@ const AppRoutes = () =>
   ]);
 
 root.render(
-  <Router>
-    <ScrollToTop>
-      <div>
+  <QueryClientProvider client={queryClient}>
+    <Router>
+      <ScrollToTop>
         <main>
           <ErrorBoundary>
             <AppRoutes />
           </ErrorBoundary>
         </main>
-      </div>
-    </ScrollToTop>
-  </Router>
+      </ScrollToTop>
+    </Router>
+  </QueryClientProvider>
 );
 
 if (module.hot) {

--- a/frontend/src/query/hooks.js
+++ b/frontend/src/query/hooks.js
@@ -1,0 +1,22 @@
+import { useQuery } from "react-query";
+
+export const useGroups = () => {
+  return useQuery(["/group/"]);
+};
+
+export const useAdmission = () => {
+  const query = useQuery(["/admission/"]);
+  // The API seemingly supports multiple admissions at the same time,
+  // but it is not currently being used.
+  // Thus this hook only returns the first, as that is all that is
+  // currently used in the project.
+  return { ...query, data: query.data ? query.data[0] : undefined };
+};
+
+export const useApplications = () => {
+  return useQuery(["/application/"]);
+};
+
+export const useMyApplication = () => {
+  return useQuery(["/application/mine/"]);
+};

--- a/frontend/src/query/mutations.js
+++ b/frontend/src/query/mutations.js
@@ -1,0 +1,9 @@
+import { useMutation } from "react-query";
+import { callApiFromQuery } from "../utils/callApi";
+
+export const useDeleteApplicationMutation = () =>
+  useMutation(() => {
+    return callApiFromQuery("/application/mine/", {
+      method: "DELETE",
+    });
+  });

--- a/frontend/src/query/queries.js
+++ b/frontend/src/query/queries.js
@@ -1,0 +1,6 @@
+import { callApiFromQuery } from "../utils/callApi";
+
+export const defaultQueryFn = async ({ queryKey }) => {
+  const path = typeof queryKey === "string" ? queryKey : queryKey[0];
+  return await callApiFromQuery(path);
+};

--- a/frontend/src/routes/ApplicationForm/index.js
+++ b/frontend/src/routes/ApplicationForm/index.js
@@ -23,23 +23,9 @@ const FormContainer = ({
   isEditingApplication,
   handleReset,
 }) => {
-  const _toggleGroup = (name) => {
-    toggleGroup(name.toLowerCase());
-  };
-
   const onCancelEdit = () => {
     toggleIsEditing();
     handleReset();
-  };
-
-  const onDeleteApplication = () => {
-    callApi("/application/mine/", {
-      method: "DELETE",
-    }).then(() => {
-      toggleIsEditing();
-      sessionStorage.clear();
-      window.location = "/";
-    });
   };
 
   const hasSelected =
@@ -72,11 +58,10 @@ const FormContainer = ({
       handleSubmit={handleSubmit}
       groups={groups}
       selectedGroups={selectedGroups}
-      toggleGroup={_toggleGroup}
+      toggleGroup={toggleGroup}
       toggleIsEditing={toggleIsEditing}
       isEditing={isEditingApplication}
       myApplication={myApplication}
-      onDeleteApplication={onDeleteApplication}
       onCancel={onCancelEdit}
     />
   );

--- a/frontend/src/routes/ApplicationPortal.js
+++ b/frontend/src/routes/ApplicationPortal.js
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 
-import callApi from "src/utils/callApi";
 import djangoData from "src/utils/djangoData";
+
+import { useAdmission, useMyApplication, useGroups } from "src/query/hooks";
 
 import ApplicationForm from "src/routes/ApplicationForm";
 import GroupsPage from "src/routes/GroupsPage";
@@ -10,28 +12,24 @@ import AdminPage from "src/routes/AdminPage";
 import AdminPageAbakusLeaderView from "src/routes/AdminPageAbakusLeaderView";
 
 import LoadingBall from "src/components/LoadingBall";
+import NavBar from "src/components/NavBar";
 
 import * as Sentry from "@sentry/browser";
-import NavBar from "src/components/NavBar";
-import { useLocation } from "react-router-dom";
 
 const ApplicationPortal = () => {
-  const [admission, setAdmission] = useState(null);
-  const [results] = useState(undefined);
-  const [groups, setGroups] = useState([]);
-  const [error, setError] = useState(null);
-  const [isFetching, setIsFetching] = useState(true);
-  const [myApplication, setMyApplication] = useState(undefined);
   const [selectedGroups, setSelectedGroups] = useState({});
-  const [user, setUser] = useState(null);
   const [isEditingApplication, setIsEditingApplication] = useState(true);
 
   const location = useLocation();
 
+  const { data: groups, isFetching } = useGroups();
+  const { data: myApplication } = useMyApplication();
+  const { data: admission, error } = useAdmission();
+
   const toggleGroup = (name) => {
     setSelectedGroups({
       ...selectedGroups,
-      [name.toLowerCase()]: !selectedGroups[name],
+      [name.toLowerCase()]: !selectedGroups[name.toLowerCase()],
     });
   };
 
@@ -61,39 +59,18 @@ const ApplicationPortal = () => {
   };
 
   useEffect(() => {
-    callApi("/group/").then(
-      ({ jsonData }) => {
-        setGroups(jsonData);
-        setIsFetching(false);
-      },
-      (error) => {
-        setError(error);
-        setIsFetching(false);
-      }
-    );
-    djangoData.user &&
-      djangoData.user.has_application &&
-      callApi("/application/mine/").then(({ jsonData }) => {
-        setMyApplication(jsonData);
-        setSelectedGroups(
-          jsonData.group_applications
-            .map((a) => a.group.name.toLowerCase())
-            .reduce((obj, a) => ({ ...obj, [a]: true }), {})
-        );
-      });
-    setUser(djangoData.user);
     Sentry.setUser(djangoData.user);
     initializeState();
-
-    callApi("/admission/").then(
-      ({ jsonData: data }) => {
-        setAdmission(data[0]);
-      },
-      (error) => {
-        setError(error);
-      }
-    );
   }, []);
+
+  useEffect(() => {
+    if (!myApplication) return;
+    setSelectedGroups(
+      myApplication.group_applications
+        .map((a) => a.group.name.toLowerCase())
+        .reduce((obj, a) => ({ ...obj, [a]: true }), {})
+    );
+  }, [myApplication]);
 
   useEffect(() => {
     persistState();
@@ -101,19 +78,9 @@ const ApplicationPortal = () => {
 
   useEffect(() => {
     persistState();
-    callApi("/application/mine/").then(({ jsonData }) => {
-      setMyApplication(jsonData);
-      if (jsonData !== undefined) {
-        setSelectedGroups(
-          jsonData.group_applications
-            .map((a) => a.group.name.toLowerCase())
-            .reduce((obj, a) => ({ ...obj, [a]: true }), {})
-        );
-      }
-    });
   }, [isEditingApplication]);
 
-  if (!user) {
+  if (!djangoData.user) {
     return null;
   } else if (error) {
     return <div>Error: {error.message}</div>;
@@ -122,20 +89,12 @@ const ApplicationPortal = () => {
   } else {
     return (
       <PageWrapper>
-        <NavBar user={user} isEditing={isEditingApplication} />
+        <NavBar user={djangoData.user} isEditing={isEditingApplication} />
         <ContentContainer>
           {location.pathname.startsWith("/velg-komiteer") && (
             <GroupsPage
               toggleGroup={toggleGroup}
-              admission={admission}
-              results={results}
-              groups={groups}
-              error={error}
-              isFetching={isFetching}
-              myApplication={myApplication}
               selectedGroups={selectedGroups}
-              user={user}
-              isEditingApplication={isEditingApplication}
             />
           )}
           {location.pathname.startsWith("/min-soknad") && (
@@ -143,41 +102,18 @@ const ApplicationPortal = () => {
               toggleGroup={toggleGroup}
               toggleIsEditing={toggleIsEditing}
               admission={admission}
-              results={results}
               groups={groups}
               error={error}
-              isFetching={isFetching}
               myApplication={myApplication}
               selectedGroups={selectedGroups}
-              user={user}
               isEditingApplication={isEditingApplication}
             />
           )}
           {location.pathname.startsWith("/admin") &&
-            (user.is_superuser ? (
-              <AdminPageAbakusLeaderView
-                admission={admission}
-                results={results}
-                groups={groups}
-                error={error}
-                isFetching={isFetching}
-                myApplication={myApplication}
-                selectedGroups={selectedGroups}
-                user={user}
-                isEditingApplication={isEditingApplication}
-              />
+            (djangoData.user.is_superuser ? (
+              <AdminPageAbakusLeaderView />
             ) : (
-              <AdminPage
-                admission={admission}
-                results={results}
-                groups={groups}
-                error={error}
-                isFetching={isFetching}
-                myApplication={myApplication}
-                selectedGroups={selectedGroups}
-                user={user}
-                isEditingApplication={isEditingApplication}
-              />
+              <AdminPage />
             ))}
         </ContentContainer>
       </PageWrapper>

--- a/frontend/src/routes/GroupsPage/index.js
+++ b/frontend/src/routes/GroupsPage/index.js
@@ -4,8 +4,11 @@ import LegoButton from "src/components/LegoButton";
 import Icon from "src/components/Icon";
 import styled from "styled-components";
 import { media } from "src/styles/mediaQueries";
+import { useGroups } from "../../query/hooks";
 
-const GroupsPage = ({ groups, selectedGroups, toggleGroup }) => {
+const GroupsPage = ({ selectedGroups, toggleGroup }) => {
+  const { data: groups } = useGroups();
+
   const handleToggleGroup = (name) => {
     toggleGroup(name.toLowerCase());
   };

--- a/frontend/src/routes/LandingPage/index.js
+++ b/frontend/src/routes/LandingPage/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
+import { useAdmission, useMyApplication } from "../../query/hooks";
 
-import callApi from "src/utils/callApi";
 import Moment from "react-moment";
 import "moment/locale/nb";
 Moment.globalLocale = "nb";
@@ -17,41 +17,33 @@ import AdmissionCountDown from "../../components/AdmissionCountDown";
 import LoadingBall from "src/components/LoadingBall";
 
 const LandingPage = () => {
-  const [admission, setAdmission] = useState(null);
-  const [error, setError] = useState(null);
-  const [isLoading, setIsLoading] = useState(true);
   const [hasSubmitted, setHasSubmitted] = useState(false);
 
-  useEffect(() => {
-    callApi("/admission/").then(
-      ({ jsonData: data }) => {
-        setAdmission(data[0]);
-        setIsLoading(false);
-      },
-      (error) => {
-        setError(error);
-      }
-    );
-    djangoData.user.full_name &&
-      callApi("/application/mine/").then(
-        (res) => {
-          // HTTP 204 will return no content, but the promise is still Fulfilled
-          if (res && res.status == 204) {
-            setHasSubmitted(false);
-          } else {
-            setHasSubmitted(true);
-            setIsLoading(false);
-          }
-        },
-        () => setHasSubmitted(false)
-      );
-  }, []);
+  const {
+    data: admission,
+    error: admissionError,
+    isFetching: admissionIsFetching,
+  } = useAdmission();
+  const {
+    data: myApplication,
+    error: myApplicationError,
+    isFetching: myApplicationIsFetching,
+  } = useMyApplication();
 
-  if (error) {
-    return <div>Error: {error.message}</div>;
+  useEffect(() => {
+    if (!myApplication) return;
+    setHasSubmitted(myApplication !== null);
+  }, [myApplication]);
+
+  if (admissionError || myApplicationError) {
+    return (
+      <div>
+        Error: {admissionError} {myApplicationError}
+      </div>
+    );
   }
 
-  if (isLoading) {
+  if (admissionIsFetching || myApplicationIsFetching) {
     return <LoadingBall />;
   }
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-loadable": "5.5.0",
     "react-moment": "^1.1.2",
     "react-motion": "^0.5.2",
+    "react-query": "^4.0.0",
     "react-router-dom": "6.3.0",
     "react-test-renderer": "^18.2.0",
     "react-textarea-autosize": "^8.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1710,6 +1710,11 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
+"@tanstack/query-core@^4.0.0-beta.1":
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.0.10.tgz#cae6f818006616dc72c95c863592f5f68b47548a"
+  integrity sha512-9LsABpZXkWZHi4P1ozRETEDXQocLAxVzQaIhganxbNuz/uA3PsCAJxJTiQrknG5htLMzOF5MqM9G10e6DCxV1A==
+
 "@types/babel__core@^7.1.7":
   version "7.1.19"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.19.tgz#7b497495b7d1b4812bdb9d02804d0576f43ee460"
@@ -1834,6 +1839,11 @@
   integrity sha512-454hrj5gz/FXcUE20ygfEiN4DxZ1sprUo0V1gqIqkNZ/CzoEzAZEll2uxMsuyz6BYjiQan4Aa65xbTemfzW9hQ==
   dependencies:
     schema-utils "*"
+
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
 "@typescript-eslint/eslint-plugin@^5.5.0":
   version "5.30.6"
@@ -8562,6 +8572,15 @@ react-motion@^0.5.2:
     prop-types "^15.5.8"
     raf "^3.1.0"
 
+react-query@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-4.0.0.tgz#d8a5347503d0aedebc957e35b408c4aa3f726580"
+  integrity sha512-qiW+Yvbl+EK8iwPDJAj4qWAKceh+g8Up8jxoNxJbzhV3bNheeyHF3EyynnkDO3S+CYgSwtCUFaP8vOjB62j7xQ==
+  dependencies:
+    "@tanstack/query-core" "^4.0.0-beta.1"
+    "@types/use-sync-external-store" "^0.0.3"
+    use-sync-external-store "^1.2.0"
+
 react-router-dom@6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
@@ -10501,6 +10520,11 @@ use-latest@^1.2.1:
   integrity sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==
   dependencies:
     use-isomorphic-layout-effect "^1.1.1"
+
+use-sync-external-store@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Moving towards using `react-query` for all API calls.

Currently the actions performed from forms still use callApi() directly, but I realized the formik-code (what's used to build the forms) that's in use uses class components and thus doesn't support hooks yet.  
I'll change that, but this works so far so I'll rather get this merged and convert forms to functional components in a new PR.

This PR changes all the GET calls, plus delete mutations - and the next PR will take care of all the other mutations.