### PR TITLE
Move initialization of calcTimeDiff method before usage

### DIFF
--- a/frontend/src/components/AdmissionCountDown/index.jsx
+++ b/frontend/src/components/AdmissionCountDown/index.jsx
@@ -2,9 +2,16 @@ import React, { useEffect, useState } from "react";
 import { DateTime } from "luxon";
 
 const AdmissionCountDown = ({ endTime: endTimeString }) => {
-  const [timeDiff, setTimeDiff] = useState(calcTimeDiff());
-
   const endTime = DateTime.fromISO(endTimeString);
+  const calcTimeDiff = () => {
+    const time = endTime.toRelative();
+
+    // If it's 1 day left we would like to say 'i morgen' and not 1 day
+    const isTomorrow = DateTime.now().plus({ days: 1 }).hasSame(endTime, "day");
+    return isTomorrow ? "i morgen" : time;
+  };
+
+  const [timeDiff, setTimeDiff] = useState(calcTimeDiff());
 
   useEffect(() => {
     const updateTimeDiffInterval = setInterval(
@@ -15,14 +22,6 @@ const AdmissionCountDown = ({ endTime: endTimeString }) => {
       clearInterval(updateTimeDiffInterval);
     };
   }, []);
-
-  const calcTimeDiff = () => {
-    const time = endTime.toRelative();
-
-    // If it's 1 day left we would like to say 'i morgen' and not 1 day
-    const isTomorrow = DateTime.now().plus({ days: 1 }).hasSame(endTime, "day");
-    return isTomorrow ? "i morgen" : time;
-  };
 
   return (
     <p style={{ alignContent: "center" }}>


### PR DESCRIPTION
For some reason I now started to get an error when loading the LandingPage component because calcTimeDiff was used before it was initialized
`Cannot access 'calcTimeDiff' before initialization`