### PR TITLE
Update admissions for revy

### DIFF
--- a/committee_admissions/oauth.py
+++ b/committee_admissions/oauth.py
@@ -20,15 +20,15 @@ class LegoOAuth2(BaseOAuth2):
     ]
 
     LEGO_GROUP_NAMES = [
-        "Arrkom",
-        "Bankkom",
-        "Bedkom",
-        "Fagkom",
-        "Koskom",
-        "LaBamba",
-        "readme",
-        "PR",
-        "Webkom",
+        "Band",
+        "Dans",
+        "Kostyme",
+        "Manus",
+        "PR-revy",
+        "Scene",
+        "Skuespill",
+        "Sosial",
+        "Teknikk",
     ]
 
     def get_scope(self):
@@ -130,11 +130,8 @@ def update_custom_user_details(strategy, details, user=None, *args, **kwargs):
         user.is_superuser = False
         for group, membership in group_data:
             # This check finds the leader of Abakus by looking at the group leader
-            # of Hovedstyret. This is the only superuser of this application.
-            if (
-                group["name"] == "Hovedstyret"
-                and membership["role"] == constants.LEADER
-            ):
+            # of RevyStyret. This is the only superuser of this application.
+            if group["name"] == "RevyStyret":
                 user.is_superuser = True
                 continue
 

--- a/committee_admissions/templates/index.html
+++ b/committee_admissions/templates/index.html
@@ -10,8 +10,8 @@
     <meta name="theme-color" content="#000000">
     <meta property="og:url" content="{{ settings.FRONTEND_URL }}">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Søk komité!">
-    <meta property="og:description" content="Vil du være med å bidra til at Abakus skal fortsette å være den beste linjeforeningen? Da må du søke komité! ">
+    <meta property="og:title" content="Søk Abakus!">
+    <meta property="og:description" content="Vil du være med å bidra til at Abakus skal fortsette å være den beste linjeforeningen? Da må du søke! ">
     <meta property="og:image" content="{% static "39922758_10157833098769535_6098752564164034560_o.jpg" %}">
     <!--
       manifest.json provides metadata used when your web app is added to the

--- a/frontend/src/components/GroupCard/index.jsx
+++ b/frontend/src/components/GroupCard/index.jsx
@@ -3,29 +3,18 @@ import styled from "styled-components";
 import { media } from "src/styles/mediaQueries";
 import readmeIfy from "src/components/ReadmeLogo";
 
-const GroupCard = ({
-  onToggle,
-  isChosen,
-  name,
-  description,
-  readMoreLink,
-  logo,
-}) => {
+const GroupCard = ({ onToggle, isChosen, name, description }) => {
   return (
     <Card onClick={() => onToggle(name)} isChosen={isChosen}>
-      <Logo src={logo} />
       <Name>{readmeIfy(name)}</Name>
       <Description>{readmeIfy(description, true)}</Description>
-      <LearnMoreLink href={`${readMoreLink}`} target="_blank">
-        Les mer på abakus.no
-      </LearnMoreLink>
       <SelectedMark isChosen={isChosen}>
         {isChosen ? (
           <SelectedMarkText isChosen={isChosen}>
             Valgt <span>- klikk for å fjerne</span>
           </SelectedMarkText>
         ) : (
-          <SelectedMarkText>Velg komité</SelectedMarkText>
+          <SelectedMarkText>Velg gruppe</SelectedMarkText>
         )}
       </SelectedMark>
     </Card>
@@ -39,11 +28,10 @@ export default GroupCard;
 export const Card = styled.div`
   display: grid;
   grid-template-columns: 1fr 3fr;
-  grid-template-rows: 2rem 1fr 1.5rem;
+  grid-template-rows: 2rem 1fr;
   grid-template-areas:
-    ". name"
-    "logo text"
-    ". readmore";
+    "name name"
+    "text text";
   grid-gap: 10px 20px;
   background: var(--lego-white);
   box-shadow: ${(props) =>

--- a/frontend/src/components/NavBar/index.jsx
+++ b/frontend/src/components/NavBar/index.jsx
@@ -12,7 +12,7 @@ const NavBar = ({ user, isEditing }) => (
     </BrandContainer>
     {!user.has_application || isEditing ? (
       <NavItemsContainer>
-        <NavItem to="/velg-komiteer" text="Velg komiteer" />
+        <NavItem to="/velg-grupper" text="Velg grupper" />
         <NavItem to="/min-soknad" text="Min søknad" />
       </NavItemsContainer>
     ) : (

--- a/frontend/src/components/ReadmeLogo.jsx
+++ b/frontend/src/components/ReadmeLogo.jsx
@@ -1,39 +1,6 @@
 import React from "react";
-import styled from "styled-components";
 
-const ReadmeLogo = () => <Readme>readme</Readme>;
-const ReadmeLogoBody = () => <ReadmeBody>readme</ReadmeBody>;
-
-const readmeIfy = (text, isBodyText = false) =>
-  text && (
-    <span>
-      {text
-        .split(/readme/)
-        .reduce(
-          (prev, current, i) =>
-            i
-              ? prev.concat(
-                  isBodyText ? (
-                    <ReadmeLogoBody key={current} />
-                  ) : (
-                    <ReadmeLogo key={current} />
-                  ),
-                  current
-                )
-              : [current],
-          []
-        )}
-    </span>
-  );
+const readmeIfy = (text) =>
+  text && <span>{text.replaceAll("PR-revy", "PR")}</span>;
 
 export default readmeIfy;
-
-/** Styles **/
-
-const Readme = styled.div`
-  font-family: "OCR A Extended", var(--font-family);
-  font-weight: 400;
-  text-transform: lowercase;
-`;
-
-const ReadmeBody = Readme.withComponent("span");

--- a/frontend/src/containers/GroupApplication/Application.jsx
+++ b/frontend/src/containers/GroupApplication/Application.jsx
@@ -27,7 +27,6 @@ const Application = ({
   return (
     <Container>
       <LogoNameWrapper>
-        <Logo src={group.logo} />
         <Name>{readmeIfy(group.name)}</Name>
       </LogoNameWrapper>
       {responseLabel && (

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -57,7 +57,7 @@ const App = ({ children }) => {
 const AppRoutes = () =>
   useRoutes([
     { path: "/", element: <LandingPage /> },
-    { path: "/velg-komiteer", element: <ApplicationPortal /> },
+    { path: "/velg-grupper", element: <ApplicationPortal /> },
     { path: "/min-soknad", element: <ApplicationPortal /> },
     { path: "/admin", element: <ApplicationPortal /> },
     { path: "*", element: <NotFoundPage /> },

--- a/frontend/src/routes/AdminPage/form.jsx
+++ b/frontend/src/routes/AdminPage/form.jsx
@@ -82,15 +82,15 @@ const InnerForm = ({ updateGroupMutation, handleSubmit, isValid }) => {
         <EditGroupFormWrapper>
           <Field
             component={TextAreaField}
-            title="Endre beskrivelsen av komiteen"
+            title="Endre beskrivelsen av gruppen"
             name="description"
-            placeholder="Skriv en beskrivelse av komiteen..."
+            placeholder="Skriv en beskrivelse av gruppen..."
           />
           <Field
             component={TextAreaField}
-            title="Endre hva komitteen ønsker å høre om fra søkere"
+            title="Endre hva gruppen ønsker å høre om fra søkere"
             name="response_label"
-            placeholder="Skriv hva komitteen ønsker å vite om søkeren..."
+            placeholder="Skriv hva gruppen ønsker å vite om søkeren..."
           />
         </EditGroupFormWrapper>
         <SubmitButton

--- a/frontend/src/routes/AdminPage/index.jsx
+++ b/frontend/src/routes/AdminPage/index.jsx
@@ -18,9 +18,9 @@ import {
   Statistics,
   StatisticsName,
   StatisticsWrapper,
-  GroupLogo,
   GroupLogoWrapper,
 } from "./styles";
+import readmeIfy from "src/components/ReadmeLogo";
 
 const AdminPage = () => {
   const [sortedApplications, setSortedApplications] = useState([]);
@@ -88,8 +88,7 @@ const AdminPage = () => {
       <PageWrapper>
         <PageTitle>Admin Panel</PageTitle>
         <GroupLogoWrapper>
-          <GroupLogo src={group.logo} />
-          <h2>{djangoData.user.representative_of_group}</h2>
+          <h2>{readmeIfy(djangoData.user.representative_of_group)}</h2>
         </GroupLogoWrapper>
         <LinkLink to="/">Gå til forside</LinkLink>
 

--- a/frontend/src/routes/AdminPageAbakusLeaderView/GroupStatistics.jsx
+++ b/frontend/src/routes/AdminPageAbakusLeaderView/GroupStatistics.jsx
@@ -3,6 +3,7 @@ import React from "react";
 import StatisticsName from "./StatisticsName";
 import StatisticsWrapper from "./StatisticsWrapper";
 import StatisticsGroupLogo from "./StatisticsGroupLogo";
+import readmeIfy from "src/components/ReadmeLogo";
 
 const GroupStatistics = ({ applications, groupName, groupLogo }) => {
   const calculateNumGroupApplications = (group) => {
@@ -21,7 +22,7 @@ const GroupStatistics = ({ applications, groupName, groupLogo }) => {
   return (
     <StatisticsWrapper smallerMargin>
       <StatisticsGroupLogo src={groupLogo} />
-      <StatisticsName capitalize>{groupName}</StatisticsName>
+      <StatisticsName capitalize>{readmeIfy(groupName)}</StatisticsName>
       {count} stk
     </StatisticsWrapper>
   );

--- a/frontend/src/routes/AdminPageAbakusLeaderView/index.jsx
+++ b/frontend/src/routes/AdminPageAbakusLeaderView/index.jsx
@@ -24,7 +24,7 @@ const AdminPageAbakusLeaderView = () => {
   const csvHeaders = [
     { label: "Full Name", key: "name" },
     { label: "Prioriteringer", key: "priorityText" },
-    { label: "Komité", key: "group" },
+    { label: "Gruppe", key: "group" },
     { label: "Søknadstekst", key: "groupApplicationText" },
     { label: "Email", key: "email" },
     { label: "Mobilnummer", key: "phoneNumber" },

--- a/frontend/src/routes/ApplicationForm/FormStructure.jsx
+++ b/frontend/src/routes/ApplicationForm/FormStructure.jsx
@@ -5,7 +5,6 @@ import Icon from "src/components/Icon";
 import LegoButton from "src/components/LegoButton";
 import PriorityTextField from "./PriorityTextField";
 import PhoneNumberField from "./PhoneNumberField";
-import ToggleGroups from "./ToggleGroups";
 import ErrorFocus from "./ErrorFocus";
 import { useMyApplication } from "src/query/hooks";
 import {
@@ -31,9 +30,6 @@ import {
 
 const FormStructure = ({
   admission,
-  groups,
-  selectedGroups,
-  toggleGroup,
   hasSelected,
   SelectedGroupItems,
   handleSubmit,
@@ -68,17 +64,17 @@ const FormStructure = ({
           <HelpText>
             <Icon name="information-circle-outline" />
             Mobilnummeret vil bli brukt til å kalle deg inn på intervju av
-            komitéledere.
+            revystyret.
           </HelpText>
           <Field name="phoneNumber" component={PhoneNumberField} />
 
           <HelpText>
             <Icon name="information-circle-outline" />
-            Kun leder av Abakus kan se det du skriver inn i prioriterings- og
+            Kun revystyret kan se det du skriver inn i prioriterings- og
             kommentarfeltet.
             <Icon name="information-circle-outline" />
             Det er ikke sikkert prioriteringslisten vil bli tatt hensyn til.
-            Ikke søk på en komité du ikke ønsker å bli med i.
+            Ikke søk på en gruppe du ikke ønsker å bli med i.
           </HelpText>
           <Field
             name="priorityText"
@@ -91,34 +87,27 @@ const FormStructure = ({
         <GroupsSection>
           <Sidebar>
             <div>
-              <SectionHeader>Komiteer</SectionHeader>
+              <SectionHeader>Grupper</SectionHeader>
               <HelpText>
                 <Icon name="information-circle-outline" />
-                Her skriver du søknaden til komiteen(e) du har valgt. Hver
-                komité kan kun se søknaden til sin egen komité.
+                Her skriver du søknaden til gruppen(e) du har valgt.
               </HelpText>
-
-              <ToggleGroups
-                groups={groups}
-                selectedGroups={selectedGroups}
-                toggleGroup={toggleGroup}
-              />
             </div>
           </Sidebar>
           {hasSelected ? (
             <Applications>{SelectedGroupItems}</Applications>
           ) : (
             <NoChosenGroupsWrapper>
-              <NoChosenTitle>Du har ikke valgt noen komiteer.</NoChosenTitle>
+              <NoChosenTitle>Du har ikke valgt noen grupper.</NoChosenTitle>
               <NoChosenSubTitle>
-                Velg i sidemargen eller gå til komiteoversikten
+                Velg i sidemargen eller gå til gruppeoversikten
               </NoChosenSubTitle>
               <LegoButton
                 icon="arrow-forward"
                 iconPrefix="ios"
-                to="/velg-komiteer"
+                to="/velg-grupper"
               >
-                Velg komiteer
+                Velg grupper
               </LegoButton>
             </NoChosenGroupsWrapper>
           )}
@@ -146,12 +135,11 @@ const FormStructure = ({
             )}
             <SubmitInfo>
               Oppdateringer etter søknadsfristen kan ikke garanteres å bli sett
-              av komiteen(e) du søker deg til.
+              av revystyret.
             </SubmitInfo>
             <SubmitInfo>
-              Din søknad til hver komité kan kun ses av den aktuelle komiteen og
-              leder av Abakus. All søknadsinformasjon slettes etter opptaket er
-              gjennomført.
+              Din søknad til hver gruppe kan kun ses av revystyret. All
+              søknadsinformasjon slettes etter opptaket er gjennomført.
             </SubmitInfo>
             <SubmitInfo>Du kan når som helst trekke søknaden din.</SubmitInfo>
           </div>

--- a/frontend/src/routes/ApplicationForm/FormStructureStyle.jsx
+++ b/frontend/src/routes/ApplicationForm/FormStructureStyle.jsx
@@ -266,6 +266,7 @@ export const NoChosenGroupsWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   margin-top: 5rem;
+  margin-bottom: 5rem;
   text-align: center;
 
   ${media.portrait`

--- a/frontend/src/routes/ApplicationForm/ToggleGroups.jsx
+++ b/frontend/src/routes/ApplicationForm/ToggleGroups.jsx
@@ -26,10 +26,10 @@ const ToggleGroups = ({ groups, selectedGroups, toggleGroup }) => {
     <Wrapper>
       <Title>Endre dine valg</Title>
       <Tooltip>
-        Klikk på logoene til komiteene for å legge til/fjerne de fra søknaden.
+        Klikk på logoene til gruppene for å legge til/fjerne de fra søknaden.
       </Tooltip>
       <IconsWrapper>{ChooseGroupsItems}</IconsWrapper>
-      <LinkToOverview to="/velg-komiteer">
+      <LinkToOverview to="/velg-grupper">
         Eller gå tilbake til oversikten for å lese mer
       </LinkToOverview>
     </Wrapper>

--- a/frontend/src/routes/ApplicationPortal.jsx
+++ b/frontend/src/routes/ApplicationPortal.jsx
@@ -90,7 +90,7 @@ const ApplicationPortal = () => {
       <PageWrapper>
         <NavBar user={djangoData.user} isEditing={isEditingApplication} />
         <ContentContainer>
-          {location.pathname.startsWith("/velg-komiteer") && (
+          {location.pathname.startsWith("/velg-grupper") && (
             <GroupsPage
               toggleGroup={toggleGroup}
               selectedGroups={selectedGroups}

--- a/frontend/src/routes/GroupsPage/index.jsx
+++ b/frontend/src/routes/GroupsPage/index.jsx
@@ -31,7 +31,10 @@ const GroupsPage = ({ selectedGroups, toggleGroup }) => {
 
   return (
     <PageWrapper>
-      <Title>Velg de komiteene du vil søke på og gå videre</Title>
+      <Title>Velg de gruppene du vil søke på og gå videre</Title>
+      <ReadMoreLink href="//abakus.no/pages/grupper/104-revyen" target="_blank">
+        Les mer om revygruppene på abakus.no
+      </ReadMoreLink>
       <GroupsWrapper>{GroupCards}</GroupsWrapper>
       <NextButtonWrapper>
         <LegoButton
@@ -45,7 +48,7 @@ const GroupsPage = ({ selectedGroups, toggleGroup }) => {
         {!hasSelectedAnything() && (
           <ErrorMessage>
             <Icon name="information-circle-outline" />
-            Du må velge en eller flere komiteer før du kan gå videre
+            Du må velge en eller flere grupper før du kan gå videre
           </ErrorMessage>
         )}
       </NextButtonWrapper>
@@ -70,7 +73,7 @@ export const PageWrapper = styled.div`
 export const Title = styled.h1`
   color: rgba(129, 129, 129, 0.59);
   font-size: 1.3rem;
-  margin: 1.6rem 0 2rem;
+  margin: 1.6rem 0 0;
   line-height: 1.5em;
 
   ${media.handheld`
@@ -78,6 +81,18 @@ export const Title = styled.h1`
     font-size: 1.2rem;
     line-height: 1.2em;
   `};
+`;
+
+const ReadMoreLink = styled.a`
+  text-align: center;
+  margin: 1em 0 2em;
+  font-weight: 600;
+  align-self: center;
+  font-size: 1rem;
+
+  &:hover {
+    text-decoration: underline;
+  }
 `;
 
 export const GroupsWrapper = styled.div`

--- a/frontend/src/routes/LandingPage/LandingPageNoAdmission.jsx
+++ b/frontend/src/routes/LandingPage/LandingPageNoAdmission.jsx
@@ -13,8 +13,7 @@ const LandingPageNoAdmission = () => {
       <InfoBox>
         <DecorativeLine vertical />
         <p>
-          Komiteeopptak skjer vanligvis i september etter semesterstart. Følg
-          med på{" "}
+          Opptak skjer vanligvis i september etter semesterstart. Følg med på{" "}
           <a href="https://abakus.no" target="_blank" rel="noopener noreferrer">
             abakus.no
           </a>{" "}

--- a/frontend/src/routes/LandingPage/LandingPageSkeleton.jsx
+++ b/frontend/src/routes/LandingPage/LandingPageSkeleton.jsx
@@ -10,7 +10,7 @@ const LandingPageSkeleton = ({ children }) => {
       <BrandContainer>
         <AbakusLogo />
       </BrandContainer>
-      <Title>Opptak til komiteer</Title>
+      <Title>Opptak til Abakusrevyen</Title>
       {children}
     </Container>
   );

--- a/frontend/src/routes/LandingPage/index.jsx
+++ b/frontend/src/routes/LandingPage/index.jsx
@@ -49,22 +49,29 @@ const LandingPage = () => {
 
   return (
     <LandingPageSkeleton>
-      <YearOfAdmission>
-        <FormatTime format="yyyy">{admission.public_deadline}</FormatTime>
-      </YearOfAdmission>
+      <YearOfAdmission>2023</YearOfAdmission>
       <InfoBox>
         <DecorativeLine vertical red />
         <ApplicationDateInfo admission={admission} />
       </InfoBox>
       <Notice>
         <StyledSpan bold>Merk:</StyledSpan> Oppdateringer etter søknadsfristen
-        kan ikke garanteres å bli sett av komiteen(e) du søker deg til.
+        kan ikke garanteres å bli sett av revystyret.
       </Notice>
+      {admission.is_open && !djangoData.user.full_name && (
+        <Notice>
+          Er du ikke medlem av Abakus? Søk via{" "}
+          <a href="https://docs.google.com/forms/d/e/1FAIpQLSfsR40RJxjvv23BUeK7wrz8j5BxxLWJwC3DO8eLrABsJFOwzQ/viewform?usp=sf_link">
+            dette skjemaet
+          </a>
+          .
+        </Notice>
+      )}
       <LinkWrapper>
         {djangoData.user.full_name ? (
           <li>
             <LegoButton
-              to={hasSubmitted ? "/min-soknad" : "/velg-komiteer"}
+              to={hasSubmitted ? "/min-soknad" : "/velg-grupper"}
               icon="arrow-forward"
               iconPrefix="ios"
               disabled={!admission.is_open}
@@ -170,6 +177,7 @@ const Notice = styled.p`
   font-style: italic;
   font-size: 1rem;
   max-width: 600px;
+  width: 600px;
   line-height: 1.4rem;
 
   ${media.handheld`

--- a/frontend/src/routes/ReceiptForm/FormStructure.jsx
+++ b/frontend/src/routes/ReceiptForm/FormStructure.jsx
@@ -75,12 +75,11 @@ const FormStructure = ({ toggleIsEditing }) => {
                   </FormatTime>
                 </StyledSpan>
               )}{" "}
-              og komiteene vil kun se den siste versjonen.
+              og revystyret vil kun se den siste versjonen.
             </Text>
             <Notice>
               <StyledSpan bold>Merk:</StyledSpan> Oppdateringer etter
-              søknadsfristen kan ikke garanteres å bli sett av komiteen(e) du
-              søker deg til.
+              søknadsfristen kan ikke garanteres å bli sett av revystyret.
             </Notice>
           </EditInfo>
           <EditActions>
@@ -132,7 +131,7 @@ const FormStructure = ({ toggleIsEditing }) => {
           <HelpText>
             <Icon name="information-circle-outline" />
             Mobilnummeret vil bli brukt til å kalle deg inn på intervju av
-            komitéledere.
+            revystyret.
           </HelpText>
           <Field
             name="phoneNumber"
@@ -142,11 +141,11 @@ const FormStructure = ({ toggleIsEditing }) => {
 
           <HelpText>
             <Icon name="information-circle-outline" />
-            Kun leder av Abakus kan se det du skriver inn i prioriterings- og
+            Kun revystyret kan se det du skriver inn i prioriterings- og
             kommentarfeltet.
             <Icon name="information-circle-outline" />
             Det er ikke sikkert prioriteringslisten vil bli tatt hensyn til.
-            Ikke søk på en komité du ikke ønsker å bli med i.
+            Ikke søk på en gruppe du ikke ønsker å bli med i.
           </HelpText>
           <Field
             name="priorityText"
@@ -160,11 +159,10 @@ const FormStructure = ({ toggleIsEditing }) => {
         <GroupsSection>
           <Sidebar>
             <div>
-              <SectionHeader>Komiteer</SectionHeader>
+              <SectionHeader>Grupper</SectionHeader>
               <HelpText>
                 <Icon name="information-circle-outline" />
-                Her skriver du søknaden til komiteen(e) du har valgt. Hver
-                komité kan kun se søknaden til sin egen komité.
+                Her skriver du søknaden til gruppen(e) du har valgt.
               </HelpText>
             </div>
           </Sidebar>
@@ -188,16 +186,16 @@ const FormStructure = ({ toggleIsEditing }) => {
             </Applications>
           ) : (
             <NoChosenGroupsWrapper>
-              <NoChosenTitle>Du har ikke valgt noen komiteer.</NoChosenTitle>
+              <NoChosenTitle>Du har ikke valgt noen grupper.</NoChosenTitle>
               <NoChosenSubTitle>
-                Send inn en ny søknad for å velge komitéer.
+                Send inn en ny søknad for å velge revygrupper.
               </NoChosenSubTitle>
               <LegoButton
                 icon="arrow-forward"
                 iconPrefix="ios"
-                to="/velg-komiteer"
+                to="/velg-grupper"
               >
-                Velg komiteer
+                Velg grupper
               </LegoButton>
             </NoChosenGroupsWrapper>
           )}


### PR DESCRIPTION
This PR is supposed to be pushed to production, and then reverted after the revy-admission is ended to be replaced by a more practical approach of running multiple admissions at the same time.

Changes:
* All occurences of the word committee and it's variations have been replaced by group
* All members of RevyStyret get superuser privileges instead of only the leader of Hovedstyret
* Images are removed, as revy does not use logos for the different groups
* A link to a google form for non-abakus applications is shown in the landing page when the admission is open and the user is not yet logged in.

Preview
![image](https://user-images.githubusercontent.com/13599770/189501684-02a83813-534e-406b-99b4-3a9c648fc8d4.png)
![image](https://user-images.githubusercontent.com/13599770/189501695-b49a817b-42c3-494e-84cc-27e2df4ff6e6.png)
![image](https://user-images.githubusercontent.com/13599770/189501715-2abfcb27-e31b-4c22-b405-3deb96be8249.png)
![image](https://user-images.githubusercontent.com/13599770/189501731-80036ba7-88dc-40d9-a276-6478ac952c8a.png)
![image](https://user-images.githubusercontent.com/13599770/189501745-f43c2784-211c-4588-8a3a-9f6010cfc498.png)
![image](https://user-images.githubusercontent.com/13599770/189501828-4a001d9b-cfc7-47d4-96dd-685075b9b1ea.png)
