### PR TITLE
Remove copy webpack-stats from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ RUN pip install --no-cache -r requirements/production.txt
 
 COPY . /app/
 COPY --from=frontend-builder /app/assets/bundles /app/assets/bundles
-COPY --from=frontend-builder /app/webpack-stats.json /app/
 
 RUN set -e \
     && ENV_CONFIG=0 python manage.py collectstatic --noinput


### PR DESCRIPTION
Trying to copy webpack-stats.json fails CI on deploy now that webpack is no longer used