### PR TITLE
Compile production dependencies

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -35,6 +35,7 @@ django==4.0.7
     #   -r requirements/base.in
     #   django-cors-headers
     #   django-extensions
+    #   django-vite
     #   djangorestframework
 django-cors-headers==3.13.0
     # via -r requirements/base.in
@@ -42,7 +43,7 @@ django-environ==0.9.0
     # via -r requirements/base.in
 django-extensions==3.2.0
     # via -r requirements/base.in
-django-webpack-loader==1.6.0
+django-vite==2.0.2
     # via -r requirements/base.in
 djangorestframework==3.13.1
     # via -r requirements/base.in


### PR DESCRIPTION
It slipped our minds to compile the production dependencies when removing webpack and adding vite, and without this the production deployment doesn't work.