### PR TITLE
Convert allowed hosts variable to list for Django v4

### DIFF
--- a/committee_admissions/settings/production.py
+++ b/committee_admissions/settings/production.py
@@ -11,7 +11,7 @@ env = environ.Env(DEBUG=(bool, False))
 
 DEBUG = env("DEBUG")
 SECRET_KEY = env("SECRET_KEY")
-ALLOWED_HOSTS = env("ALLOWED_HOSTS")
+ALLOWED_HOSTS = env("ALLOWED_HOSTS").split(",")
 FRONTEND_URL = env("FRONTEND_URL")
 API_URL = env("API_URL")
 ENVIRONMENT_NAME = env("ENVIRONMENT_NAME", default="production")


### PR DESCRIPTION
As of Django 4, the ALLOWED_HOSTS variable is required to be a list or a tuple.  
This should make sure it is always parsed as a list.