### PR TITLE
Enable sorting for any column in the abakusleader-view

### DIFF
--- a/frontend/src/components/Icon.tsx
+++ b/frontend/src/components/Icon.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import styled, { Interpolation } from "styled-components";
 
 // See https://ionicons.com/ for icon names. md or ios as prefix.
 
@@ -7,6 +7,7 @@ interface IconProps extends IconStyleProps {
   name: string;
   title?: string;
   prefix?: string;
+  styles?: Interpolation<React.CSSProperties>;
 }
 
 const Icon: React.FC<IconProps> = ({
@@ -16,6 +17,7 @@ const Icon: React.FC<IconProps> = ({
   color,
   padding,
   prefix = "md",
+  styles,
 }) => (
   <Ionicon
     className={`ion-${prefix}-${name}`}
@@ -23,6 +25,7 @@ const Icon: React.FC<IconProps> = ({
     color={color}
     title={title}
     padding={padding}
+    styles={styles}
   />
 );
 
@@ -34,13 +37,16 @@ interface IconStyleProps {
   size?: string | number;
   color?: string;
   padding?: string | number;
+  styles?: Interpolation<React.CSSProperties>;
 }
 
 const Ionicon = styled.i.attrs((props: IconStyleProps) => ({
   size: props.size || "2rem",
   color: props.color || "inherit",
   padding: props.padding || "0",
+  styles: props.styles,
 }))`
+  ${({ styles }) => styles}
   font-size: ${(props) => props.size};
   line-height: 1;
   color: ${(props) => props.color};

--- a/frontend/src/containers/AdmissionsContainer/Columns.tsx
+++ b/frontend/src/containers/AdmissionsContainer/Columns.tsx
@@ -16,6 +16,7 @@ export const columns = [
         {table.getIsAllRowsExpanded() ? "▼" : "►"}
       </span>
     ),
+    size: 1,
     cell: ({ row }) => (
       <span onClick={() => row.toggleExpanded()}>
         {row.getIsExpanded() ? "▼" : "►"}
@@ -36,6 +37,7 @@ export const columns = [
   }),
   columnHelper.accessor("createdAt", {
     header: "Sendt",
+    size: 170,
     cell: (info) => (
       <>
         <FormatTime format="EEEE d. MMMM, kl. HH:mm ">
@@ -56,6 +58,7 @@ export const columns = [
   }),
   columnHelper.accessor("updatedAt", {
     header: "Oppdatert",
+    size: 170,
     cell: (info) => (
       <>
         <FormatTime format="EEEE d. MMMM, kl. HH:mm">
@@ -66,6 +69,7 @@ export const columns = [
   }),
   columnHelper.accessor("numApplications", {
     header: "Søknader",
+    size: 1,
     cell: (info) => info.row.original.numApplications,
   }),
 ];

--- a/frontend/src/containers/AdmissionsContainer/index.tsx
+++ b/frontend/src/containers/AdmissionsContainer/index.tsx
@@ -6,6 +6,8 @@ import {
   Row,
   getExpandedRowModel,
   ExpandedState,
+  SortingState,
+  getSortedRowModel,
 } from "@tanstack/react-table";
 import { columns } from "./Columns";
 import AdmissionsInnerTable, { InnerTableValues } from "./InnerTable";
@@ -35,6 +37,7 @@ const AdmissionsContainer: React.FC<AdmissionsContainerProps> = ({
   applications,
 }) => {
   const [expanded, setExpanded] = useState<ExpandedState>({});
+  const [sorting, setSorting] = useState<SortingState>([]);
   const data = useMemo(
     () =>
       applications.map((application) => ({
@@ -64,10 +67,13 @@ const AdmissionsContainer: React.FC<AdmissionsContainerProps> = ({
     data,
     state: {
       expanded,
+      sorting,
     },
     onExpandedChange: setExpanded,
+    onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
+    getSortedRowModel: getSortedRowModel(),
   });
 
   const subComponent = React.useCallback(
@@ -94,12 +100,25 @@ const AdmissionsContainer: React.FC<AdmissionsContainerProps> = ({
             <tr key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
                 <th key={header.id}>
-                  {header.isPlaceholder
-                    ? null
-                    : flexRender(
+                  {header.isPlaceholder ? null : (
+                    <div
+                      style={
+                        header.column.getCanSort()
+                          ? { cursor: "pointer" }
+                          : undefined
+                      }
+                      onClick={header.column.getToggleSortingHandler()}
+                    >
+                      {flexRender(
                         header.column.columnDef.header,
                         header.getContext()
                       )}
+                      {{
+                        asc: " 🔼",
+                        desc: " 🔽",
+                      }[header.column.getIsSorted() as string] ?? null}
+                    </div>
+                  )}
                 </th>
               ))}
             </tr>

--- a/frontend/src/containers/AdmissionsContainer/index.tsx
+++ b/frontend/src/containers/AdmissionsContainer/index.tsx
@@ -15,6 +15,9 @@ import SubComponentWrapper from "./SubComponentWrapper";
 import SubComponentHeader from "./SubComponentHeader";
 import { Application } from "src/types";
 import { useState } from "react";
+import { TableWrapper } from "src/routes/AdminPageAbakusLeaderView/Wrapper";
+import styled from "styled-components";
+import Icon from "src/components/Icon";
 
 interface AdmissionsContainerProps {
   applications: Application[];
@@ -93,13 +96,13 @@ const AdmissionsContainer: React.FC<AdmissionsContainerProps> = ({
   );
 
   return (
-    <div>
-      <table>
+    <TableWrapper>
+      <StyledTable>
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
-                <th key={header.id}>
+                <th key={header.id} style={{ width: header.getSize() }}>
                   {header.isPlaceholder ? null : (
                     <div
                       style={
@@ -114,8 +117,8 @@ const AdmissionsContainer: React.FC<AdmissionsContainerProps> = ({
                         header.getContext()
                       )}
                       {{
-                        asc: " 🔼",
-                        desc: " 🔽",
+                        asc: <SortArrow name="arrow-dropup" />,
+                        desc: <SortArrow name="arrow-dropdown" />,
                       }[header.column.getIsSorted() as string] ?? null}
                     </div>
                   )}
@@ -129,7 +132,7 @@ const AdmissionsContainer: React.FC<AdmissionsContainerProps> = ({
             <React.Fragment key={row.id}>
               <tr>
                 {row.getVisibleCells().map((cell) => (
-                  <td key={cell.id}>
+                  <td key={cell.id} style={{ width: cell.column.getSize() }}>
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </td>
                 ))}
@@ -144,9 +147,23 @@ const AdmissionsContainer: React.FC<AdmissionsContainerProps> = ({
             </React.Fragment>
           ))}
         </tbody>
-      </table>
-    </div>
+      </StyledTable>
+    </TableWrapper>
   );
 };
+
+const StyledTable = styled.table`
+  width: 100%;
+  min-width: 850px;
+`;
+
+const SortArrow = ({ name }: { name: string }) => (
+  <Icon
+    name={name}
+    size="24px"
+    padding="0 0 0 5px"
+    styles={{ verticalAlign: "text-top" }}
+  />
+);
 
 export default AdmissionsContainer;

--- a/frontend/src/routes/AdminPageAbakusLeaderView/Wrapper.tsx
+++ b/frontend/src/routes/AdminPageAbakusLeaderView/Wrapper.tsx
@@ -1,10 +1,22 @@
 import styled from "styled-components";
 import { Card } from "src/components/Card";
+import { media } from "src/styles/mediaQueries";
 
 const Wrapper = styled(Card)`
-  width: 50em;
+  width: 80%;
+  max-width: 100%;
   min-height: 30em;
   padding: 0;
+
+  ${media.handheld`
+    width: auto;
+    padding: 0 10px;
+  `};
 `;
 
 export default Wrapper;
+
+export const TableWrapper = styled.div`
+  max-width: 100%;
+  overflow-x: auto;
+`;


### PR DESCRIPTION
Fixes ABA-186, ABA-188

## Changes
AbakusLeader-view:
* Enable sorting for any column
* Set content width to 80% of screen size instead of 50em for all screen sizes (now 100% width for handheld devices)
    * Table turns to horizontal scroll if the available space is less than 850px
* Set date columns to fit in one line when enough screen-width is available

## Visual preview
### Sorting
Default - sorted the way it was returned from the backend
![image](https://user-images.githubusercontent.com/13599770/207430499-4a4dcb2c-954d-4317-8b0b-a448b3b2904b.png)
Clicked once - ascending
![image](https://user-images.githubusercontent.com/13599770/208265473-cc9b89fa-1f53-416c-b2f2-a76b4c23785e.png)
Clicked twice - descending
![image](https://user-images.githubusercontent.com/13599770/208265482-931d9f62-9974-42cc-aa0d-21525598f753.png)
