### PR TITLE
Remove hardcoded timezone

### DIFF
--- a/frontend/src/components/Time/FormatTime.tsx
+++ b/frontend/src/components/Time/FormatTime.tsx
@@ -7,9 +7,7 @@ interface FormatTimeProps {
 }
 
 const FormatTime: React.FC<FormatTimeProps> = ({ format, children }) => {
-  const formatted = DateTime.fromISO(children, { zone: "utc" })
-    .setLocale("no")
-    .toFormat(format);
+  const formatted = DateTime.fromISO(children).setLocale("no").toFormat(format);
 
   return <span>{formatted}</span>;
 };


### PR DESCRIPTION
The timezone was set to a hardcoded utc. This should be changed to either;

1. Luxon automatically uses the timezone that's local to the device (as proposed in this PR)
2. Some variety of "Norway/Oslo" or "cet"(/"cest" if necessary)

Resolves ABA-190